### PR TITLE
Extending CI 

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -7,8 +7,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest] # TODO update this when going online
-        python-version: [3.8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         pytest --pyargs qibojit
     - name: Test with jit disabled
+      if: startsWith(matrix.os, 'ubuntu')
       run: |
         NUMBA_DISABLE_JIT=1 pytest --cov=qibojit --cov-report=xml --pyargs qibojit
     - name: Upload coverage to Codecov

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,8 +11,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8] # TODO update this when going online
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install wheel
-        python setup.py sdist
+        python setup.py sdist bdist_wheel
     - name: Store wheels as artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install wheel
-        python setup.py sdist bdist_wheel
+        python setup.py sdist
     - name: Store wheels as artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Runtime requirements for qibojit
 
 numba
-cupy
+cupy-cuda113
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Runtime requirements for qibojit
 
 numba
-cupy-cuda113
+cupy
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # Runtime requirements for qibojit
 
 numba
-cupy-cuda113
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Runtime requirements for qibojit
 
 numba
-cupy-cuda112
+cupy-cuda113
 psutil

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,11 @@ def get_version():
 # Read in requirements
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
+if sys.platform == 'darwin': # remove cupy for macos
+    for index in range(len(requirements)):
+        if 'cupy' in requirements[index]:
+            requirements.pop(index)
+            break
 
 
 # load long description from README

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from setuptools import setup, find_packages
 import os
 import re
+import sys
 
 PACKAGE = "qibojit"
 
@@ -22,6 +23,10 @@ def get_version():
 # Read in requirements
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
+if sys.platform == 'darwin': # remove cupy for macos
+    for i in range(len(requirements)):
+        if 'cupy' in requirements[i]:
+            requirements.pop(i)
 
 
 # load long description from README

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ def get_version():
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
 if sys.platform == 'darwin': # remove cupy for macos
-    for i in range(len(requirements)):
-        if 'cupy' in requirements[i]:
-            requirements.pop(i)
+    for index in range(len(requirements)):
+        if 'cupy' in requirements[index]:
+            requirements.pop(index)
 
 
 # load long description from README

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,6 @@ def get_version():
 # Read in requirements
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
-if sys.platform == 'darwin': # remove cupy for macos
-    for index in range(len(requirements)):
-        if 'cupy' in requirements[index]:
-            requirements.pop(index)
-            break
 
 
 # load long description from README

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ if sys.platform == 'darwin': # remove cupy for macos
     for index in range(len(requirements)):
         if 'cupy' in requirements[index]:
             requirements.pop(index)
+            break
 
 
 # load long description from README

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 from setuptools import setup, find_packages
 import os
 import re
-import sys
 
 PACKAGE = "qibojit"
 

--- a/src/qibojit/__init__.py
+++ b/src/qibojit/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.1-dev"
+__version__ = "0.0.1.dev0"

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -117,8 +117,8 @@ class CupyBackend(AbstractBackend): # pragma: no cover
     def __init__(self):
         import os
         import numpy as np
-        import cupy as cp
-        import cupy_backends
+        import cupy as cp  # pylint: disable=import-error
+        import cupy_backends  # pylint: disable=import-error
         try:
             if not cp.cuda.runtime.getDeviceCount(): # pragma: no cover
                 raise RuntimeError("Cannot use cupy backend if GPU is not available.")


### PR DESCRIPTION
Extends CI to other operating systems. It seems that the cupy does not offer precompiled versions for macos. Unfortunately the pure `cupy` package is not simple to install on CI.

I believe we should consider removing cupy from the requirements of macos builds. I believe the code will crash if cupy is not installed, @stavros11 could you please have a look?