### PR TITLE
Tracing to reduce compilation impact 

### DIFF
--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -85,7 +85,8 @@ class NumbaBackend(AbstractBackend):
         state = self.two_qubit_base(state, 3, 0, 1, "apply_fsim", gate=gate2)
         state = self.two_qubit_base(state, 3, 0, 1, "apply_fsim", qubits=qubits, gate=gate2)
 
-        probs = self.np.abs(state) ** 2
+        probs = self.np.random.random(8)
+        probs = probs / probs.sum()
         freqs = self.np.zeros(8, dtype=self.np.int64)
         freqs = self.measure_frequencies(freqs, probs, 100, 3, 1234, None)
         state = self.collapse_state(state, (0,), 0, 3, True)

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -62,7 +62,7 @@ class NumbaBackend(AbstractBackend):
         return self.np.array(x)
 
     def tracing(self, dtype):
-        """Dummy calls to all kernels during backend creation to increase dry run performance."""
+        """Compile kernels during backend creation to increase dry run performance."""
         qubits = (0, 1)
         state = (self.np.random.random(4) + 1j * self.np.random.random(4)).astype(dtype)
         gate = (self.np.random.random((2, 2)) + 1j * self.np.random.random((2, 2))).astype(dtype)


### PR DESCRIPTION
Fixes #15. I included dummy calls to all kernels during backend creation, so that they are executed when the user does `import qibojit` and enables the corresponding backend. Here are some benchmarks on CPU:

<details>
<summary>H gate</summary>

nqubits | dry_run_time_no_tracing | dry_run_time_tracing | simulation_time_no_tracing | simulation_time_tracing
-- | -- | -- | -- | --
3 | 0.03883 | 0.00101 | 0.00012 | 0.00018
4 | 0.04029 | 0.00094 | 0.00015 | 0.00017
5 | 0.03869 | 0.00102 | 0.00017 | 0.00020
6 | 0.03887 | 0.00126 | 0.00020 | 0.00022
7 | 0.04002 | 0.00107 | 0.00025 | 0.00025
8 | 0.03970 | 0.00122 | 0.00025 | 0.00034
9 | 0.03897 | 0.00123 | 0.00027 | 0.00029
10 | 0.04122 | 0.00123 | 0.00031 | 0.00032
11 | 0.03903 | 0.00116 | 0.00033 | 0.00034
12 | 0.04511 | 0.00120 | 0.00037 | 0.00045
13 | 0.04036 | 0.00130 | 0.00050 | 0.00041
14 | 0.03932 | 0.00123 | 0.00043 | 0.00044
15 | 0.03951 | 0.00115 | 0.00050 | 0.00050
16 | 0.04073 | 0.00190 | 0.00060 | 0.00061
17 | 0.03985 | 0.00215 | 0.00076 | 0.00071
18 | 0.04072 | 0.00241 | 0.00111 | 0.00119
19 | 0.04227 | 0.00304 | 0.00176 | 0.00174
20 | 0.04662 | 0.00497 | 0.00272 | 0.00293
21 | 0.05479 | 0.00838 | 0.00843 | 0.00807
22 | 0.05543 | 0.01318 | 0.01361 | 0.01444
23 | 0.07568 | 0.02717 | 0.02684 | 0.02605
24 | 0.14193 | 0.09118 | 0.07672 | 0.08226
25 | 0.26921 | 0.22878 | 0.21630 | 0.22906
26 | 0.54258 | 0.48731 | 0.46803 | 0.48327
27 | 1.04616 | 0.99224 | 0.99331 | 0.99309
28 | 2.06012 | 2.03047 | 1.99716 | 1.98241
29 | 4.22786 | 4.15998 | 4.09199 | 4.10959
30 | 8.55268 | 8.53007 | 8.45776 | 8.45357

</details>
<details>
<summary>X gate</summary>

nqubits | dry_run_time_no_tracing | dry_run_time_tracing | simulation_time_no_tracing | simulation_time_tracing
-- | -- | -- | -- | --
3 | 0.03906 | 0.00087 | 0.00012 | 0.00014
4 | 0.03890 | 0.00086 | 0.00016 | 0.00017
5 | 0.03908 | 0.00095 | 0.00018 | 0.00023
6 | 0.03861 | 0.00094 | 0.00020 | 0.00022
7 | 0.03835 | 0.00126 | 0.00024 | 0.00025
8 | 0.03899 | 0.00098 | 0.00026 | 0.00027
9 | 0.03889 | 0.00077 | 0.00028 | 0.00029
10 | 0.03898 | 0.00103 | 0.00030 | 0.00032
11 | 0.03935 | 0.00115 | 0.00031 | 0.00042
12 | 0.03890 | 0.00130 | 0.00036 | 0.00037
13 | 0.03929 | 0.00123 | 0.00040 | 0.00050
14 | 0.03911 | 0.00138 | 0.00043 | 0.00044
15 | 0.03947 | 0.00161 | 0.00047 | 0.00052
16 | 0.03960 | 0.00180 | 0.00052 | 0.00054
17 | 0.03951 | 0.00219 | 0.00072 | 0.00064
18 | 0.04126 | 0.00227 | 0.00115 | 0.00112
19 | 0.04216 | 0.00430 | 0.00150 | 0.00166
20 | 0.04686 | 0.00457 | 0.00217 | 0.00233
21 | 0.04941 | 0.00813 | 0.00813 | 0.00796
22 | 0.06655 | 0.01104 | 0.01187 | 0.01114
23 | 0.07404 | 0.02505 | 0.02061 | 0.02204
24 | 0.09690 | 0.08203 | 0.04291 | 0.07608
25 | 0.27174 | 0.22117 | 0.22328 | 0.21543
26 | 0.53316 | 0.47668 | 0.47367 | 0.46639
27 | 1.03854 | 0.97954 | 0.96412 | 0.96038
28 | 2.04613 | 2.00222 | 1.97958 | 1.97868
29 | 4.16524 | 4.12108 | 4.08635 | 4.08787
30 | 8.47480 | 8.44756 | 8.44690 | 8.42881

</details>
<details>
<summary>Z gate</summary>

nqubits | dry_run_time_no_tracing | dry_run_time_tracing | simulation_time_no_tracing | simulation_time_tracing
-- | -- | -- | -- | --
3 | 0.03887 | 0.00095 | 0.00012 | 0.00015
4 | 0.03896 | 0.00111 | 0.00015 | 0.00018
5 | 0.03876 | 0.00112 | 0.00018 | 0.00020
6 | 0.03962 | 0.00098 | 0.00020 | 0.00021
7 | 0.03977 | 0.00092 | 0.00025 | 0.00025
8 | 0.03938 | 0.00109 | 0.00028 | 0.00028
9 | 0.03890 | 0.00189 | 0.00027 | 0.00028
10 | 0.04000 | 0.00107 | 0.00030 | 0.00032
11 | 0.04269 | 0.00113 | 0.00032 | 0.00034
12 | 0.03977 | 0.00112 | 0.00035 | 0.00038
13 | 0.03990 | 0.00125 | 0.00038 | 0.00054
14 | 0.03889 | 0.00121 | 0.00041 | 0.00043
15 | 0.03854 | 0.00131 | 0.00044 | 0.00045
16 | 0.04293 | 0.00162 | 0.00049 | 0.00062
17 | 0.03925 | 0.00212 | 0.00061 | 0.00060
18 | 0.04039 | 0.00285 | 0.00096 | 0.00099
19 | 0.04362 | 0.00309 | 0.00140 | 0.00137
20 | 0.04329 | 0.00515 | 0.00187 | 0.00201
21 | 0.04815 | 0.01269 | 0.00721 | 0.00730
22 | 0.05148 | 0.01005 | 0.01086 | 0.01072
23 | 0.06545 | 0.01974 | 0.01901 | 0.01917
24 | 0.11028 | 0.05267 | 0.05032 | 0.04857
25 | 0.17808 | 0.13269 | 0.12970 | 0.12903
26 | 0.34624 | 0.31691 | 0.28981 | 0.29540
27 | 0.66572 | 0.59874 | 0.60049 | 0.60252
28 | 1.27480 | 1.21778 | 1.21357 | 1.20480
29 | 2.57943 | 2.52021 | 2.46787 | 2.47242
30 | 5.09619 | 5.11328 | 5.07868 | 5.08505

</details>
<details>
<summary>U1 gate</summary>

nqubits | dry_run_time_no_tracing | dry_run_time_tracing | simulation_time_no_tracing | simulation_time_tracing
-- | -- | -- | -- | --
3 | 0.03991 | 0.00531 | 0.00012 | 0.00012
4 | 0.03933 | 0.00512 | 0.00015 | 0.00014
5 | 0.03892 | 0.00506 | 0.00017 | 0.00017
6 | 0.03904 | 0.00563 | 0.00019 | 0.00020
7 | 0.03870 | 0.00519 | 0.00023 | 0.00023
8 | 0.04001 | 0.00523 | 0.00026 | 0.00025
9 | 0.03923 | 0.00612 | 0.00029 | 0.00034
10 | 0.04727 | 0.00524 | 0.00043 | 0.00030
11 | 0.03901 | 0.00544 | 0.00032 | 0.00033
12 | 0.03982 | 0.00529 | 0.00036 | 0.00036
13 | 0.04058 | 0.00534 | 0.00040 | 0.00039
14 | 0.04431 | 0.00545 | 0.00044 | 0.00043
15 | 0.03947 | 0.00646 | 0.00047 | 0.00056
16 | 0.03952 | 0.00571 | 0.00050 | 0.00053
17 | 0.03956 | 0.00630 | 0.00062 | 0.00060
18 | 0.04101 | 0.00613 | 0.00099 | 0.00096
19 | 0.04185 | 0.00628 | 0.00143 | 0.00140
20 | 0.04610 | 0.00929 | 0.00189 | 0.00196
21 | 0.04585 | 0.01174 | 0.00623 | 0.00745
22 | 0.05105 | 0.01568 | 0.01210 | 0.01122
23 | 0.07235 | 0.02469 | 0.01923 | 0.01878
24 | 0.09319 | 0.05991 | 0.03914 | 0.05181
25 | 0.17419 | 0.14351 | 0.12904 | 0.13499
26 | 0.33601 | 0.28957 | 0.29448 | 0.29540
27 | 0.66967 | 0.61394 | 0.60510 | 0.59597
28 | 1.27847 | 1.23286 | 1.21042 | 1.20997
29 | 2.57013 | 2.55760 | 2.48110 | 2.48676
30 | 5.18837 | 5.11972 | 5.08512 | 5.07799

</details>
<details>
<summary>Variational</summary>

nqubits | dry_run_time_no_tracing | dry_run_time_tracing | simulation_time_no_tracing | simulation_time_tracing
-- | -- | -- | -- | --
3 | 0.32801 | 0.00139 | 0.00025 | 0.00027
4 | 0.04223 | 0.00156 | 0.00034 | 0.00043
5 | 0.04756 | 0.00169 | 0.00039 | 0.00050
6 | 0.04242 | 0.00182 | 0.00050 | 0.00051
7 | 0.04255 | 0.00181 | 0.00055 | 0.00055
8 | 0.04273 | 0.00182 | 0.00070 | 0.00066
9 | 0.04276 | 0.00214 | 0.00069 | 0.00078
10 | 0.04325 | 0.00271 | 0.00077 | 0.00098
11 | 0.04326 | 0.00281 | 0.00090 | 0.00106
12 | 0.05009 | 0.00286 | 0.00093 | 0.00120
13 | 0.04305 | 0.00324 | 0.00101 | 0.00127
14 | 0.04337 | 0.00287 | 0.00112 | 0.00115
15 | 0.04333 | 0.00342 | 0.00129 | 0.00160
16 | 0.04381 | 0.00331 | 0.00149 | 0.00150
17 | 0.04742 | 0.00422 | 0.00178 | 0.00185
18 | 0.04780 | 0.00565 | 0.00294 | 0.00318
19 | 0.05194 | 0.00692 | 0.00383 | 0.00384
20 | 0.05415 | 0.01029 | 0.00612 | 0.00621
21 | 0.06286 | 0.01822 | 0.01495 | 0.01462
22 | 0.07207 | 0.02555 | 0.02596 | 0.02631
23 | 0.10188 | 0.05336 | 0.05225 | 0.05164
24 | 0.26765 | 0.15188 | 0.17923 | 0.13180
25 | 0.53185 | 0.51606 | 0.50273 | 0.50413
26 | 1.12934 | 1.10084 | 1.09080 | 1.07534
27 | 2.31296 | 2.27511 | 2.18202 | 2.18210
28 | 4.67028 | 4.62523 | 4.56733 | 4.56500
29 | 9.39009 | 9.43142 | 9.28382 | 9.28754
30 | 19.46835 | 19.47182 | 19.38908 | 19.41174

</details>
<details>
<summary>QFT</summary>

nqubits | dry_run_time_no_tracing | dry_run_time_tracing | simulation_time_no_tracing | simulation_time_tracing
-- | -- | -- | -- | --
3 | 0.34139 | 0.00609 | 0.00022 | 0.00035
4 | 0.04578 | 0.00690 | 0.00035 | 0.00043
5 | 0.04498 | 0.00635 | 0.00049 | 0.00049
6 | 0.04501 | 0.00651 | 0.00064 | 0.00066
7 | 0.04543 | 0.00654 | 0.00083 | 0.00085
8 | 0.04581 | 0.00671 | 0.00108 | 0.00110
9 | 0.04628 | 0.00823 | 0.00123 | 0.00161
10 | 0.04650 | 0.00726 | 0.00151 | 0.00155
11 | 0.04730 | 0.00797 | 0.00177 | 0.00185
12 | 0.04832 | 0.00805 | 0.00210 | 0.00214
13 | 0.04829 | 0.00836 | 0.00254 | 0.00244
14 | 0.04852 | 0.00907 | 0.00282 | 0.00280
15 | 0.05031 | 0.00975 | 0.00334 | 0.00322
16 | 0.05015 | 0.01051 | 0.00383 | 0.00384
17 | 0.06351 | 0.01182 | 0.00467 | 0.00452
18 | 0.05316 | 0.01525 | 0.00641 | 0.00723
19 | 0.05786 | 0.01739 | 0.00875 | 0.00849
20 | 0.06242 | 0.02166 | 0.01282 | 0.01265
21 | 0.07303 | 0.03035 | 0.02315 | 0.02308
22 | 0.09896 | 0.04934 | 0.03958 | 0.03902
23 | 0.15114 | 0.09357 | 0.08671 | 0.08417
24 | 0.30378 | 0.32358 | 0.21404 | 0.27303
25 | 1.06996 | 1.03187 | 0.95303 | 0.94591
26 | 2.65440 | 2.60621 | 2.60128 | 2.55157
27 | 5.59047 | 5.53308 | 5.50032 | 5.49488
28 | 11.66997 | 11.63067 | 11.55782 | 11.56300
29 | 24.48819 | 24.33579 | 24.25917 | 24.35532
30 | 51.28703 | 51.13320 | 51.03517 | 51.06885

</details>

As expected using tracing increases dry run performance for small circuits and up to 25 qubits, but it is pretty much useless for larger circuits. I still think it would be a useful feature to add as many applications involve executing small circuits.

I will implement something similar for GPU and update with the corresponding benchmarks here.