### PR TITLE
removing inline

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
@@ -21,7 +21,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install pylint
         pip install pytest-cov
-        pip install .[tests]
+        pip install .
+        pip install qibo --pre
     - name: Test with pylint
       run: |
         pylint src -E -d E1123,E1120

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
@@ -33,7 +33,8 @@ jobs:
     - name: Test wheels
       run: |
         python -m pip install --upgrade pip
-        pip install pytest qibo
+        pip install pytest
+        pip install qibo --pre
         pip install -r requirements.txt
         pip install qibojit --no-index --find-links ./dist/
         pytest --pyargs qibojit

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/src/qibojit/custom_operators/gates.py
+++ b/src/qibojit/custom_operators/gates.py
@@ -1,7 +1,7 @@
 from numba import prange, njit
 
 
-@njit(inline="always", cache=True)
+@njit(cache=True)
 def multicontrol_index(g, qubits):
     i = 0
     i += g


### PR DESCRIPTION
After upgrading to numba 0.54, I get:
```
UnsupportedRewriteError: Failed in nopython mode pipeline (step: convert to parfors)
Overwrite of parallel loop index

File "../qibojit/src/qibojit/custom_operators/gates.py", line 106:
def multicontrol_apply_z_pow_kernel(state, gate, qubits, nstates, m):
    <source elided>
    for g in prange(nstates):  # pylint: disable=not-an-iterable
        i = multicontrol_index(g, qubits)
        ^
```
(see https://github.com/qiboteam/qibojit/runs/3393479978?check_suite_focus=true)
So, removing the inline seems to fix this issue.
