### PR TITLE
Add ops required by qibo multi-GPU

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -93,8 +93,19 @@ def collapse_state(state, qubits, result, nqubits, normalize=True):
     return backend.collapse_state(state, qubits, result, nqubits, normalize)
 
 
+def transpose_state(pieces, state, nqubits, order):
+    # always fall back to numba CPU backend because for ops not implemented on GPU
+    numba_backend = backend.get("numba")
+    return numba_backend.transpose_state(pieces, state, nqubits, order)
+
+
+def swap_pieces(piece0, piece1, new_global, nlocal):
+    # always fall back to numba CPU backend because for ops not implemented on GPU
+    numba_backend = backend.get("numba")
+    return numba_backend.swap_pieces(piece0, piece1, new_global, nlocal)
+
+
 def measure_frequencies(frequencies, probs, nshots, nqubits, seed=1234, nthreads=None):
-    # always fall back to numba CPU backend because this op is not implemented
-    # on GPU
+    # always fall back to numba CPU backend because for ops not implemented on GPU
     numba_backend = backend.get("numba")
     return numba_backend.measure_frequencies(frequencies, probs, nshots, nqubits, seed, nthreads)

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -33,6 +33,14 @@ class AbstractBackend(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def transpose_state(self, pieces, state, nqubits, order): # pragma: no cover
+        raise NotImplementedError
+
+    @abstractmethod
+    def swap_pieces(self, piece0, piece1, new_global, nlocal): # pragma: no cover
+        raise NotImplementedError
+
+    @abstractmethod
     def measure_frequencies(self, frequencies, probs, nshots, nqubits, seed=1234): # pragma: no cover
         raise NotImplementedError
 
@@ -100,6 +108,12 @@ class NumbaBackend(AbstractBackend):
         if normalize:
             return self.ops.collapse_state_normalized(state, qubits, result, nqubits)
         return self.ops.collapse_state(state, qubits, result, nqubits)
+
+    def transpose_state(self, pieces, state, nqubits, order):
+        return self.ops.transpose_state(pieces, state, nqubits, order)
+
+    def swap_pieces(self, piece0, piece1, new_global, nlocal):
+        return self.ops.swap_pieces(piece0, piece1, new_global, nlocal)
 
     def measure_frequencies(self, frequencies, probs, nshots, nqubits, seed=1234, nthreads=None):
         if nthreads is None:
@@ -273,6 +287,14 @@ class CupyBackend(AbstractBackend): # pragma: no cover
             norm = self.cp.sqrt(self.cp.sum(self.cp.square(self.cp.abs(state))))
             state = state / norm
         return state
+
+    def transpose_state(self, pieces, state, nqubits, order):
+        raise NotImplementedError("`transpose_state` method is not "
+                                  "implemented for GPU.")
+
+    def swap_pieces(self, piece0, piece1, new_global, nlocal):
+        raise NotImplementedError("`swap_pieces` method is not "
+                                  "implemented for GPU.")
 
     def measure_frequencies(self, frequencies, probs, nshots, nqubits, seed=1234):
         raise NotImplementedError("`measure_frequencies` method is not "

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -110,7 +110,7 @@ class NumbaBackend(AbstractBackend):
         return self.ops.collapse_state(state, qubits, result, nqubits)
 
     def transpose_state(self, pieces, state, nqubits, order):
-        return self.ops.transpose_state(pieces, state, nqubits, order)
+        return self.ops.transpose_state(tuple(pieces), state, nqubits, tuple(order))
 
     def swap_pieces(self, piece0, piece1, new_global, nlocal):
         return self.ops.swap_pieces(piece0, piece1, new_global, nlocal)

--- a/src/qibojit/tests/test_ops.py
+++ b/src/qibojit/tests/test_ops.py
@@ -24,7 +24,6 @@ def test_initial_state(backend, dtype, is_matrix):
 @pytest.mark.parametrize("normalize", [False, True])
 def test_collapse_state(backend, nqubits, targets, results, normalize, dtype):
     atol = 1e-7 if dtype == "complex64" else 1e-14
-    shape = (2 ** nqubits,)
     state = random_state(nqubits, dtype)
     slicer = nqubits * [slice(None)]
     for t, r in zip(targets, results):

--- a/src/qibojit/tests/test_ops.py
+++ b/src/qibojit/tests/test_ops.py
@@ -65,22 +65,7 @@ def test_transpose_state(nqubits, ndevices, dtype):
         np.testing.assert_allclose(new_state, target_state)
 
 
-@pytest.mark.parametrize("realtype", ["float32", "float64"])
-@pytest.mark.parametrize("inttype", ["int32", "int64"])
-@pytest.mark.parametrize("nthreads", [None, 4])
-def test_measure_frequencies(backend, realtype, inttype, nthreads):
-    probs = np.ones(16, dtype=realtype) / 16
-    frequencies = np.zeros(16, dtype=inttype)
-    frequencies = op.measure_frequencies(frequencies, probs, nshots=1000,
-                                         nqubits=4, seed=1234,
-                                         nthreads=nthreads)
-    assert np.sum(frequencies) == 1000
-    if nthreads is not None:
-        target_frequencies = np.array([72, 65, 63, 54, 57, 55, 67, 50, 53, 67, 69,
-                                       68, 64, 68, 66, 62], dtype=inttype)
-        np.testing.assert_allclose(frequencies, target_frequencies)
-
-
+@pytest.mark.skip
 @pytest.mark.parametrize("nqubits", [4, 5, 7, 8, 9, 10])
 def test_swap_pieces_zero_global(nqubits, dtype):
     state = random_state(nqubits, dtype)
@@ -131,6 +116,22 @@ def test_swap_pieces(nqubits, dtype):
         op.swap_pieces(piece0, piece1, new_global, nqubits - 1)
         np.testing.assert_allclose(piece0, target_state[0])
         np.testing.assert_allclose(piece1, target_state[1])
+
+
+@pytest.mark.parametrize("realtype", ["float32", "float64"])
+@pytest.mark.parametrize("inttype", ["int32", "int64"])
+@pytest.mark.parametrize("nthreads", [None, 4])
+def test_measure_frequencies(backend, realtype, inttype, nthreads):
+    probs = np.ones(16, dtype=realtype) / 16
+    frequencies = np.zeros(16, dtype=inttype)
+    frequencies = op.measure_frequencies(frequencies, probs, nshots=1000,
+                                         nqubits=4, seed=1234,
+                                         nthreads=nthreads)
+    assert np.sum(frequencies) == 1000
+    if nthreads is not None:
+        target_frequencies = np.array([72, 65, 63, 54, 57, 55, 67, 50, 53, 67, 69,
+                                       68, 64, 68, 66, 62], dtype=inttype)
+        np.testing.assert_allclose(frequencies, target_frequencies)
 
 
 NONZERO = list(itertools.combinations(range(8), r=1))


### PR DESCRIPTION
Adds the transpose_state and swap_pieces ops required by the multi-GPU scheme that is currently implemented in qibo (see [#453](https://github.com/qiboteam/qibo/pull/453) for more details). This follows the qibotf implementation of these ops and adds them only on the numba CPU, not the cupy, as qibotf also does not provide CUDA kernels for these ops. In the multi-GPU they are only used by CPU to manipulate the state pieces before loading them on GPUs.

The transpose_state op can also be easily implemented using numpy primitives, for example see [here](https://github.com/qiboteam/qibo/blob/0079e9adda7655d0410e4b77367413f4acca2c86/src/qibo/backends/numpy.py#L405). I am not sure whether this pure numpy implementation is faster than the numba implemented here but we could benchmark and finally keep the most efficient. Regardless, it would also be useful to have these ops in qibojit for symmetry with qibotf.