### PR TITLE
adding scipy dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     ],
     install_requires=[
         "numba>=0.51.0",
+        "scipy",
         "psutil"
     ],
     extras_require={


### PR DESCRIPTION
Fix issue with `np.dot`, see https://numba.pydata.org/numba-doc/dev/reference/numpysupported.html#linear-algebra.