### PR TITLE
Fix tests and methods with AMD ROCM

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -144,6 +144,19 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
             return self.backend.asarray(super().expm(x))
         return super().expm(x)
 
+    def eigh(self, x):
+        if self.engine.name == "cupy" and self.engine.is_hip: # pragma: no cover
+            # FIXME: Fallback to numpy because eigh is not implemented in rocblas
+            result = self.np.linalg.eigh(self.to_numpy(x))
+            return self.cast(result[0]), self.cast(result[1])
+        return super().eigh(x)
+
+    def eigvalsh(self, x):
+        if self.engine.name == "cupy" and self.engine.is_hip: # pragma: no cover
+            # FIXME: Fallback to numpy because eigvalsh is not implemented in rocblas
+            return self.cast(self.np.linalg.eigvalsh(self.to_numpy(x)))
+        return super().eigvalsh(x)
+
     def unique(self, x, return_counts=False):
         if self.engine.name == "cupy": # pragma: no cover
             if isinstance(x, self.native_types):

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -165,7 +165,20 @@ class CupyBackend(AbstractBackend): # pragma: no cover
         if is_hip:  # pragma: no cover
             self.kernel_double_suffix = f"_complex_double"
             self.kernel_float_suffix = f"_complex_float"
-            self.test_regressions = {} # TODO: Fix this
+            self.test_regressions = {
+                "test_measurementresult_apply_bitflips": [
+                    [2, 2, 6, 1, 0, 0, 0, 0, 1, 0],
+                    [2, 2, 6, 1, 0, 0, 0, 0, 1, 0],
+                    [0, 0, 4, 1, 0, 0, 0, 0, 1, 0],
+                    [0, 2, 4, 0, 0, 0, 0, 0, 0, 0]
+                ],
+                "test_probabilistic_measurement": {2: 267, 3: 247, 0: 243, 1: 243},
+                "test_unbalanced_probabilistic_measurement": {3: 500, 2: 174, 0: 163, 1: 163},
+                "test_post_measurement_bitflips_on_circuit": [
+                    {5: 30}, {5: 17, 7: 7, 1: 2, 4: 2, 2: 1, 3: 1},
+                    {7: 7, 1: 5, 3: 4, 6: 4, 2: 3, 5: 3, 0: 2, 4: 2}
+                ]
+            }
         else:  # pragma: no cover
             self.kernel_double_suffix = f"<complex<double>>"
             self.kernel_float_suffix = f"<complex<float>>"

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -160,9 +160,9 @@ class CupyBackend(AbstractBackend): # pragma: no cover
         self.np = np
         self.cp = cp
         base_dir = os.path.dirname(os.path.realpath(__file__))
-        is_hip = cupy_backends.cuda.api.runtime.is_hip
+        self.is_hip = cupy_backends.cuda.api.runtime.is_hip
 
-        if is_hip:  # pragma: no cover
+        if self.is_hip:  # pragma: no cover
             self.kernel_double_suffix = f"_complex_double"
             self.kernel_float_suffix = f"_complex_float"
             self.test_regressions = {
@@ -209,7 +209,7 @@ class CupyBackend(AbstractBackend): # pragma: no cover
         kernels.append(f"initial_state_kernel{self.kernel_double_suffix}")
         kernels.append(f"initial_state_kernel{self.kernel_float_suffix}")
         kernels = tuple(kernels)
-        gates_dir = os.path.join(base_dir, "gates.hip.cc" if is_hip else "gates.cu.cc")
+        gates_dir = os.path.join(base_dir, "gates.hip.cc" if self.is_hip else "gates.cu.cc")
         with open(gates_dir, "r") as file:
             code = r"{}".format(file.read())
             self.gates = cp.RawModule(code=code, options=("--std=c++11",),

--- a/src/qibojit/tests/test_backends.py
+++ b/src/qibojit/tests/test_backends.py
@@ -53,6 +53,21 @@ def test_basic_matrices(backend):
     K.assert_allclose(K.expm(m), expm(m))
 
 
+def test_backend_eigh(backend):
+    m = np.random.random((16, 16))
+    eigvals2, eigvecs2 = np.linalg.eigh(m)
+    eigvals1, eigvecs1 = K.eigh(K.cast(m))
+    K.assert_allclose(eigvals1, eigvals2)
+    K.assert_allclose(K.abs(eigvecs1), np.abs(eigvecs2))
+
+
+def test_backend_eigvalsh(backend):
+    m = np.random.random((16, 16))
+    target = np.linalg.eigvalsh(m)
+    result = K.eigvalsh(K.cast(m))
+    K.assert_allclose(target, result)
+
+
 def test_unique_and_gather(backend):
     samples = np.random.randint(0, 2, size=(100,))
     K.assert_allclose(K.unique(samples), np.unique(samples))


### PR DESCRIPTION
Closes #34.
 - I fixed the ``rocblas_status_not_implemented`` issue by using NumPy instead of CuPy for ``eigh`` and ``eigvalsh``.
   The changes apply only to CuPy with AMD GPUs.
 - I completed the regression tests by running the tests on a machine with an AMD GPU and saving the output.

In order to close #34, we need also to merge https://github.com/qiboteam/qibo/pull/501 in the Qibo repository. 
