### PR TITLE
Use template kernels for multiqubit gates

### DIFF
--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -141,6 +141,7 @@ class NumbaBackend(AbstractBackend):
 class CupyBackend(AbstractBackend): # pragma: no cover
 
     DEFAULT_BLOCK_SIZE = 1024
+    MAX_NUM_TARGETS = 7
 
     def __init__(self):
         import os
@@ -168,7 +169,7 @@ class CupyBackend(AbstractBackend): # pragma: no cover
             kernels.append(f"{kernel}_kernel{self.kernel_float_suffix}")
             kernels.append(f"multicontrol_{kernel}_kernel{self.kernel_double_suffix}")
             kernels.append(f"multicontrol_{kernel}_kernel{self.kernel_float_suffix}")
-        for ntargets in range(3, 11):
+        for ntargets in range(3, self.MAX_NUM_TARGETS+1):
             kernels.append(f"apply_multi_qubit_gate_kernel{self.kernel_double_suffix[0:-2]}, {2**ntargets}>")
             kernels.append(f"apply_multi_qubit_gate_kernel{self.kernel_float_suffix[0:-2]}, {2**ntargets}>")
         kernels.append(f"collapse_state_kernel{self.kernel_double_suffix}")
@@ -280,6 +281,9 @@ class CupyBackend(AbstractBackend): # pragma: no cover
         assert state.dtype == gate.dtype
 
         ntargets = len(targets)
+        if ntargets > self.MAX_NUM_TARGETS:
+            raise ValueError(f"Number of target qubits must be <= {self.MAX_NUM_TARGETS}"
+                             f" but is {ntargets}.")
         if qubits is None:
             nactive = ntargets
             qubits = self.cast(sorted(nqubits - q - 1 for q in targets), dtype=self.cp.int32)

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -179,6 +179,7 @@ class CupyBackend(AbstractBackend): # pragma: no cover
         gates_dir = os.path.join(base_dir, "gates.cu.cc")
         with open(gates_dir, "r") as file:
             code = r"{}".format(file.read())
+            code = code.replace("QIBO_MAX_BLOCK_SIZE", str(self.DEFAULT_BLOCK_SIZE))
             self.gates = cp.RawModule(code=code, options=("--std=c++11",),
                                       name_expressions=kernels)
 

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -182,6 +182,7 @@ class CupyBackend(AbstractBackend): # pragma: no cover
             code = code.replace("QIBO_MAX_BLOCK_SIZE", str(self.DEFAULT_BLOCK_SIZE))
             self.gates = cp.RawModule(code=code, options=("--std=c++11",),
                                       name_expressions=kernels)
+        self.gates.compile()
 
     def calculate_blocks(self, nstates, block_size=DEFAULT_BLOCK_SIZE):
         """Compute the number of blocks and of threads per block.

--- a/src/qibojit/custom_operators/gates.cu.cc
+++ b/src/qibojit/custom_operators/gates.cu.cc
@@ -307,7 +307,7 @@ __global__ void apply_multi_qubit_gate_kernel(T* state,
     T new_state_elem = T(0., 0.); // use local variable because it is faster than global ones
     //#pragma unroll
     for (auto j = 0; j < nsubstates; j++) {
-      new_state_elem += gate[nsubstates * i + j] * buffer[i];
+      new_state_elem += gate[nsubstates * i + j] * buffer[j];
     }
     state[t] = new_state_elem;
   }

--- a/src/qibojit/custom_operators/gates.cu.cc
+++ b/src/qibojit/custom_operators/gates.cu.cc
@@ -284,7 +284,7 @@ __device__ long multitarget_index(const long* targets, long i, int ntargets) {
 
 
 // C++ implementation of gates.py:apply_multi_qubit_gate_kernel()
-template<typename T, size_t nsubstates>
+template<typename T, int nsubstates>
 __global__ void __launch_bounds__(1024) // to prevent CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES
 apply_multi_qubit_gate_kernel(T* state,
                               const T* gate,
@@ -308,6 +308,7 @@ apply_multi_qubit_gate_kernel(T* state,
     state[t] = new_state_elem;
   }
 }
+
 
 // C++ implementation of ops.py:collapse_index()
 __device__ long collapse_index(const int* qubits, long g, long h, int ntargets) {

--- a/src/qibojit/custom_operators/gates.cu.cc
+++ b/src/qibojit/custom_operators/gates.cu.cc
@@ -283,154 +283,35 @@ __device__ long multitarget_index(const long* targets, long i, int ntargets) {
 }
 
 
-// C++ implementation of gates.py:apply_three_qubit_kernel()
-template<typename T>
-__global__ void apply_three_qubit_gate_kernel(T* state,
-                                              const T* gate,
-                                              const int* qubits,
-                                              const long* targets,
-                                              int ntargets,
-                                              int ncontrols) {
-  const long g = blockIdx.x * blockDim.x + threadIdx.x;
-  const long ig = multicontrol_index(qubits, g, ncontrols);
-  const T buffer0 = state[ig - targets[0] - targets[1] - targets[2]];
-  const T buffer1 = state[ig - targets[1] - targets[2]];
-  const T buffer2 = state[ig - targets[0] - targets[2]];
-  const T buffer3 = state[ig - targets[2]];
-  const T buffer4 = state[ig - targets[0] - targets[1]];
-  const T buffer5 = state[ig - targets[1]];
-  const T buffer6 = state[ig - targets[0]];
-  const T buffer7 = state[ig];
-  for(auto i = 0; i < 8; i++) {
-    const long t = ig - multitarget_index(targets, 7 - i, ntargets);
-    state[t] = gate[i*8]   * buffer0 + gate[i*8+1] * buffer1 + gate[i*8+2] * buffer2
-             + gate[i*8+3] * buffer3 + gate[i*8+4] * buffer4 + gate[i*8+5] * buffer5
-             + gate[i*8+6] * buffer6 + gate[i*8+7] * buffer7;
-  }
-}
-
-
-// C++ implementation of gates.py:apply_four_qubit_kernels()
-template<typename T>
-__global__ void apply_four_qubit_gate_kernel(T* state,
-                                             const T* gate,
-                                             const int* qubits,
-                                             const long* targets,
-                                             int ntargets,
-                                             int ncontrols) {
-  const long g = blockIdx.x * blockDim.x + threadIdx.x;
-  const long ig = multicontrol_index(qubits, g, ncontrols);
-  const T buffer0 = state[ig - targets[0] - targets[1] - targets[2] - targets[3]];
-  const T buffer1 = state[ig - targets[1] - targets[2] - targets[3]];
-  const T buffer2 = state[ig - targets[0] - targets[2] - targets[3]];
-  const T buffer3 = state[ig - targets[2] - targets[3]];
-  const T buffer4 = state[ig - targets[0] - targets[1] - targets[3]];
-  const T buffer5 = state[ig - targets[1] - targets[3]];
-  const T buffer6 = state[ig - targets[0] - targets[3]];
-  const T buffer7 = state[ig - targets[3]];
-  const T buffer8 = state[ig - targets[0] - targets[1] - targets[2]];
-  const T buffer9 = state[ig - targets[1] - targets[2]];
-  const T buffer10 = state[ig - targets[0] - targets[2]];
-  const T buffer11 = state[ig - targets[2]];
-  const T buffer12 = state[ig - targets[0] - targets[1]];
-  const T buffer13 = state[ig - targets[1]];
-  const T buffer14 = state[ig - targets[0]];
-  const T buffer15 = state[ig];
-  for(auto i = 0; i < 16; i++) {
-    const long t = ig - multitarget_index(targets, 15 - i, ntargets);
-    state[t] = gate[i*16]    * buffer0  + gate[i*16+1]  * buffer1  + gate[i*16+2]  * buffer2
-             + gate[i*16+3]  * buffer3  + gate[i*16+4]  * buffer4  + gate[i*16+5]  * buffer5
-             + gate[i*16+6]  * buffer6  + gate[i*16+7]  * buffer7  + gate[i*16+8]  * buffer8
-             + gate[i*16+9]  * buffer9  + gate[i*16+10] * buffer10 + gate[i*16+11] * buffer11
-             + gate[i*16+12] * buffer12 + gate[i*16+13] * buffer13 + gate[i*16+14] * buffer14
-             + gate[i*16+15] * buffer15;
-  }
-}
-
-
-// C++ implementation of gates.py:apply_five_gate_kernel()
-template<typename T>
-__global__ void apply_five_qubit_gate_kernel(T* state,
-                                             const T* gate,
-                                             const int* qubits,
-                                             const long* targets,
-                                             int ntargets,
-                                             int ncontrols) {
-  const long g = blockIdx.x * blockDim.x + threadIdx.x;
-  const long ig = multicontrol_index(qubits, g, ncontrols);
-  const T buffer0 = state[ig - targets[0] - targets[1] - targets[2] - targets[3] - targets[4]];
-  const T buffer1 = state[ig - targets[1] - targets[2] - targets[3] - targets[4]];
-  const T buffer2 = state[ig - targets[0] - targets[2] - targets[3] - targets[4]];
-  const T buffer3 = state[ig - targets[2] - targets[3] - targets[4]];
-  const T buffer4 = state[ig - targets[0] - targets[1] - targets[3] - targets[4]];
-  const T buffer5 = state[ig - targets[1] - targets[3] - targets[4]];
-  const T buffer6 = state[ig - targets[0] - targets[3] - targets[4]];
-  const T buffer7 = state[ig - targets[3] - targets[4]];
-  const T buffer8 = state[ig - targets[0] - targets[1] - targets[2] - targets[4]];
-  const T buffer9 = state[ig - targets[1] - targets[2] - targets[4]];
-  const T buffer10 = state[ig - targets[0] - targets[2] - targets[4]];
-  const T buffer11 = state[ig - targets[2] - targets[4]];
-  const T buffer12 = state[ig - targets[0] - targets[1] - targets[4]];
-  const T buffer13 = state[ig - targets[1] - targets[4]];
-  const T buffer14 = state[ig - targets[0] - targets[4]];
-  const T buffer15 = state[ig - targets[4]];
-  const T buffer16 = state[ig - targets[0] - targets[1] - targets[2] - targets[3]];
-  const T buffer17 = state[ig - targets[1] - targets[2] - targets[3]];
-  const T buffer18 = state[ig - targets[0] - targets[2] - targets[3]];
-  const T buffer19 = state[ig - targets[2] - targets[3]];
-  const T buffer20 = state[ig - targets[0] - targets[1] - targets[3]];
-  const T buffer21 = state[ig - targets[1] - targets[3]];
-  const T buffer22 = state[ig - targets[0] - targets[3]];
-  const T buffer23 = state[ig - targets[3]];
-  const T buffer24 = state[ig - targets[0] - targets[1] - targets[2]];
-  const T buffer25 = state[ig - targets[1] - targets[2]];
-  const T buffer26 = state[ig - targets[0] - targets[2]];
-  const T buffer27 = state[ig - targets[2]];
-  const T buffer28 = state[ig - targets[0] - targets[1]];
-  const T buffer29 = state[ig - targets[1]];
-  const T buffer30 = state[ig - targets[0]];
-  const T buffer31 = state[ig];
-  for(auto i = 0; i < 32; i++) {
-    const long t = ig - multitarget_index(targets, 31 - i, ntargets);
-    state[t] = gate[i*32]    * buffer0  + gate[i*32+1]  * buffer1  + gate[i*32+2]  * buffer2
-             + gate[i*32+3]  * buffer3  + gate[i*32+4]  * buffer4  + gate[i*32+5]  * buffer5
-             + gate[i*32+6]  * buffer6  + gate[i*32+7]  * buffer7  + gate[i*32+8]  * buffer8
-             + gate[i*32+9]  * buffer9  + gate[i*32+10] * buffer10 + gate[i*32+11] * buffer11
-             + gate[i*32+12] * buffer12 + gate[i*32+13] * buffer13 + gate[i*32+14] * buffer14
-             + gate[i*32+15] * buffer15 + gate[i*32+16] * buffer16 + gate[i*32+17] * buffer17
-             + gate[i*32+18] * buffer18 + gate[i*32+19] * buffer19 + gate[i*32+20] * buffer20
-             + gate[i*32+21] * buffer21 + gate[i*32+22] * buffer22 + gate[i*32+23] * buffer23
-             + gate[i*32+24] * buffer24 + gate[i*32+25] * buffer25 + gate[i*32+26] * buffer26
-             + gate[i*32+27] * buffer27 + gate[i*32+28] * buffer28 + gate[i*32+29] * buffer29
-             + gate[i*32+30] * buffer30 + gate[i*32+31] * buffer31;
-  }
-}
-
-
 // C++ implementation of gates.py:apply_multi_qubit_gate_kernel()
 // In contrast to the Python version, it does not perform in-place
 // updates of the state vector, but uses a copy of it
-template<typename T>
-__global__ void apply_multi_qubit_gate_kernel(T* state, T* buffer,
+template<typename T, size_t nsubstates>
+__global__ void apply_multi_qubit_gate_kernel(T* state,
                                               const T* gate,
                                               const int* qubits,
                                               const long* targets,
-                                              long nsubstates,
                                               int ntargets,
                                               int ncontrols) {
   const long g = blockIdx.x * blockDim.x + threadIdx.x;
   const long ig = multicontrol_index(qubits, g, ncontrols);
+  T buffer[nsubstates];
+  //#pragma unroll
+  for (auto i = 0; i < nsubstates; i++) {
+    const long t = ig - multitarget_index(targets, nsubstates - i - 1, ntargets);
+    buffer[i] = state[t];
+  }
+  //#pragma unroll
   for (auto i = 0; i < nsubstates; i++) {
     const long t = ig - multitarget_index(targets, nsubstates - i - 1, ntargets);
     T new_state_elem = T(0., 0.); // use local variable because it is faster than global ones
+    //#pragma unroll
     for (auto j = 0; j < nsubstates; j++) {
-      const long u = ig - multitarget_index(targets, nsubstates - j - 1, ntargets);
-      new_state_elem += gate[nsubstates * i + j] * buffer[u];
+      new_state_elem += gate[nsubstates * i + j] * buffer[i];
     }
     state[t] = new_state_elem;
   }
 }
-
 
 // C++ implementation of ops.py:collapse_index()
 __device__ long collapse_index(const int* qubits, long g, long h, int ntargets) {

--- a/src/qibojit/custom_operators/gates.cu.cc
+++ b/src/qibojit/custom_operators/gates.cu.cc
@@ -285,7 +285,10 @@ __device__ long multitarget_index(const long* targets, long i, int ntargets) {
 
 // C++ implementation of gates.py:apply_multi_qubit_gate_kernel()
 template<typename T, int nsubstates>
-__global__ void __launch_bounds__(1024) // to prevent CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES
+__global__ void
+__launch_bounds__(QIBO_MAX_BLOCK_SIZE) // to prevent CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES.
+                                       // The maximum block size is chosen in backends.py
+                                       // and it is replaced here before compilation.
 apply_multi_qubit_gate_kernel(T* state,
                               const T* gate,
                               const int* qubits,


### PR DESCRIPTION
In this PR I implemented an alternative approach for the multi-qubit gate GPU kernels.
Instead of using hard-coded kernels + a general kernel that uses a copy of the state vector, here we use a general kernel
whose number of targets is passed as a template argument (actually ``2**ntargets``).
In this way, we match the speed of hard-coded kernels while having something which is easy to read and maintain.
The ``CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES`` raised in the hard-coded kernels was solved
by using the ``__launch_bounds__()`` command. Now we don't need to reduce the number of threads per block anymore.
Results are slightly worse than those of the hard-coded kernels, but better than the general one with the duplicated state vector (and we don't need to duplicate the state vector anymore).

I also tried to use the ``#pragma unroll`` command before the two outer ``for`` loops, but this only increased the compilation times by a lot.

In the following benchmarks, the first column refers to the ``multiqubitgpu`` branch, the second one to this PR, and the third one to the experiment with ``#pragma unroll``.

<details><summary>29 qubits - Simulation time</summary>

ntargets | Simulation time multiqubitgpu | Simulation time template | Simulation time template with unroll
-- | -- | -- | --
3 | 0.83411 | 0.83941 | 0.83976
4 | 0.92544 | 0.93479 | 0.94950
5 | 1.10846 | 1.12942 | 1.13832
6 | 1.57244 | 1.52444 | 1.54351
7 | 2.38234 | 2.38484 | 2.38015
8 | 4.12487 | 4.00351 | 4.00956
9 | 8.07915 | 7.45372 | 7.47198
10 | 16.74838 | 15.14361 | 15.17363

</details>

<details><summary>30 qubits - Simulation time</summary>

ntargets | Simulation time multiqubitgpu | Simulation time template | Simulation time template with unroll
-- | -- | -- | --
3 | 1.72150 | 1.73227 | 1.72725
4 | 1.90872 | 1.92669 | 1.94654
5 | 2.27736 | 2.30780 | 2.32227
6 | 3.21150 | 3.09786 | 3.13361
7 | 4.93511 | 4.80266 | 4.80837
8 | 8.41139 | 7.94951 | 8.00882
9 | 15.76286 | 14.48749 | 14.57002
10 | 31.71287 | 28.37985 | 28.61059

</details>

<details><summary>29 qubits - Dry run overhead</summary>

ntargets | delta multiqubitgpu | delta template | delta template with unroll
-- | -- | -- | --
3 | 0.83847 | 2.00655 | 900.98358
4 | 0.83351 | 1.14307 | 605.42221
5 | 0.82621 | 1.14018 | 607.23981
6 | 0.99430 | 1.13710 | 605.14305
7 | 0.84465 | 1.13857 | 606.16878
8 | 0.75042 | 1.14819 | 601.45140
9 | 0.74318 | 1.13734 | 602.82116
10 | 0.86632 | 1.14150 | 595.10451

</details>

<details><summary>30 qubits - Dry run overhead</summary>

ntargets | delta multiqubitgpu | delta template | delta template with unroll
-- | -- | -- | --
3 | 0.83293 | 1.13510 | 599.88374
4 | 0.83877 | 1.13440 | 599.36912
5 | 0.83159 | 1.13244 | 600.32113
6 | 0.84544 | 1.14221 | 601.81508
7 | 0.76149 | 1.13335 | 605.04759
8 | 0.80501 | 1.13652 | 598.07223
9 | 0.81188 | 1.14936 | 604.65122
10 | 0.84957 | 1.12455 | 598.04385

</details>

Two problems:
 - We need to decide which num of targets to compile and when.
 - <s> It doesn't work with ``ROCm``, it raises ``hipErrorNotFound``. </s>  (EDIT: fixed)