### PR TITLE
Add Numba GPU backend

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -1,6 +1,5 @@
 from qibo.backends.abstract import AbstractBackend, AbstractCustomOperators
 from qibo.backends.numpy import NumpyBackend
-from qibo.abstractions.states import AbstractState
 from qibo.config import raise_error
 from qibojit.custom_operators.backends import NumbaBackend
 
@@ -10,19 +9,22 @@ class CupyCpuDevice:  # pragma: no cover
 
     def __init__(self, K):
         self.K = K
+        self.original_engine = K.engine.name
 
     def __enter__(self, *args):
         self.K.set_engine("numba")
 
     def __exit__(self, *args):
         if self.K.gpu_devices:
-            self.K.set_engine("cupy")
+            self.K.set_engine(self.original_engine)
 
 
 class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
 
     description = "Uses custom operators based on numba.jit for CPU and " \
-                  "custom CUDA kernels loaded with cupy GPU."
+                  "custom CUDA kernels loaded with cupy or numba for GPU."
+
+    default_gpu_engine = "numba_gpu"
 
     def __init__(self):
         NumpyBackend.__init__(self)
@@ -32,12 +34,23 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         self.engine = None # active engine
         self._numba_engine = NumbaBackend()
         self._cupy_engine = None
+        self._numba_gpu_engine = None
 
-        try: # pragma: no cover
-            from cupy import cuda # pylint: disable=E0401
-            ngpu = cuda.runtime.getDeviceCount()
-        except:
-            ngpu = 0
+        if self.default_gpu_engine == "numba_gpu":
+            try: # pragma: no cover
+                from numba import cuda # pylint: disable=E0401
+                ngpu = len(cuda.gpus)
+            except:
+                ngpu = 0
+        elif self.default_gpu_engine == "cupy":
+            try: # pragma: no cover
+                from cupy import cuda # pylint: disable=E0401
+                ngpu = cuda.runtime.getDeviceCount()
+            except:
+                ngpu = 0
+        else:
+            raise_error(ValueError, f"Default GPU engine {self.default_gpu_engine} "
+                                     "not recognized!")
 
         import os
         if "OMP_NUM_THREADS" in os.environ: # pragma: no cover
@@ -50,7 +63,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         if self.gpu_devices: # pragma: no cover
             # CI does not use GPUs
             self.default_device = self.gpu_devices[0]
-            self.set_engine("cupy")
+            self.set_engine(self.default_gpu_engine)
         elif self.cpu_devices:
             self.default_device = self.cpu_devices[0]
             self.set_engine("numba")
@@ -73,24 +86,38 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         if name == "numba":
             import numpy as xp
             self.tensor_types = (xp.ndarray,)
+            self.native_types = (xp.ndarray,)
             self.engine = self._numba_engine
+            self.Tensor = xp.ndarray
+            self.random = xp.random
+            self.newaxis = xp.newaxis
         elif name == "cupy":
             import cupy as xp # pylint: disable=E0401
             self.tensor_types = (self.np.ndarray, xp.ndarray)
+            self.native_types = (xp.ndarray,)
+            self.Tensor = xp.ndarray
+            self.random = xp.random
+            self.newaxis = xp.newaxis
             if self._cupy_engine is None:
                 from qibojit.custom_operators.backends import CupyBackend
                 self._cupy_engine = CupyBackend()
             self.engine = self._cupy_engine
+        elif name == "numba_gpu":
+            import numpy as xp
+            from numba import cuda
+            self.tensor_types = (xp.ndarray, cuda.cudadrv.devicearray.DeviceNDArray)
+            self.native_types = (cuda.cudadrv.devicearray.DeviceNDArray,)
+            self.Tensor = cuda.cudadrv.devicearray.DeviceNDArray
+            if self._numba_gpu_engine is None:
+                from qibojit.custom_operators.backends import NumbaGPUBackend
+                self._numba_gpu_engine = NumbaGPUBackend()
+            self.engine = self._numba_gpu_engine
         else:
             raise_error(ValueError, "Unknown engine {}.".format(name))
         self.backend = xp
         self.numeric_types = (int, float, complex, xp.int32,
                               xp.int64, xp.float32, xp.float64,
                               xp.complex64, xp.complex128)
-        self.native_types = (xp.ndarray,)
-        self.Tensor = xp.ndarray
-        self.random = xp.random
-        self.newaxis = xp.newaxis
         if "GPU" in self.default_device: # pragma: no cover
             with self.device(self.default_device):
                 self.matrices.allocate_matrices()
@@ -100,7 +127,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
     def set_device(self, name):
         AbstractBackend.set_device(self, name)
         if "GPU" in name: # pragma: no cover
-            self.set_engine("cupy")
+            self.set_engine(self.default_gpu_engine)
         else:
             self.set_engine("numba")
 
@@ -114,6 +141,8 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
             return x
         elif self.engine.name == "cupy" and isinstance(x, self.engine.cp.ndarray):  # pragma: no cover
             return x.get()
+        elif self.engine.name == "numba_gpu" and isinstance(x, self.Tensor):  # pragma: no cover
+            return x.copy_to_host()
         return self.np.array(x)
 
     def cast(self, x, dtype='DTYPECPX'):
@@ -183,10 +212,16 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         # assume tf naming convention '/GPU:0'
         if self.engine.name == "numba":
             return super().device(device_name)
-        else: # pragma: no cover
+        elif self.engine.name == "cupy": # pragma: no cover
             if "GPU" in device_name:
                 device_id = int(device_name.split(":")[-1])
                 return self.backend.cuda.Device(device_id % len(self.gpu_devices))
+            else:
+                return self.cupy_cpu_device
+        else: # pragma: no cover
+            if "GPU" in device_name:
+                # FIXME: Replace the DummyModule
+                return super().device(device_name)
             else:
                 return self.cupy_cpu_device
 
@@ -303,6 +338,11 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
                 value = value.get()
             if isinstance(target, self.backend.ndarray):
                 target = target.get()
+        elif self.engine.name == "numba_gpu": # pragma: no cover
+            if isinstance(value, self.Tensor):
+                value = self.to_numpy(value)
+            if isinstance(target, self.Tensor):
+                target = self.to_numpy(target)
         self.np.testing.assert_allclose(value, target, rtol=rtol, atol=atol)
 
     def apply_gate(self, state, gate, nqubits, targets, qubits=None):
@@ -331,16 +371,16 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return self.engine.two_qubit_base(state, nqubits, *targets, "apply_fsim", qubits, gate)
 
     def apply_multi_qubit_gate(self, state, gate, nqubits, targets, qubits=None):
-        # FIXME: fall back to numba temporarily until we implement this for GPU
-        state = self.to_numpy(state)
-        gate = self.to_numpy(gate)
-        targets = self.to_numpy(targets)
-        if qubits is not None:
-            qubits = self.to_numpy(qubits)
-        return self._numba_engine.multi_qubit_base(state, nqubits, targets, qubits, gate)
+        return self.engine.multi_qubit_base(state, nqubits, targets, qubits, gate)
 
     def collapse_state(self, state, qubits, result, nqubits, normalize=True):
-        return self.engine.collapse_state(state, qubits, result, nqubits, normalize)
+        if normalize:
+            # FIXME: fall back to numba temporarily until we implement this for GPU
+            state = self.to_numpy(state)
+            qubits = self.to_numpy(qubits)
+            return self.cast(self._numba_engine.collapse_state(state, qubits, result, nqubits, normalize=True))
+        else:
+            return self.engine.collapse_state(state, qubits, result, nqubits, normalize=False)
 
     def swap_pieces(self, piece0, piece1, new_global, nlocal):
         # always fall back to numba CPU backend because for ops not implemented on GPU

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -105,9 +105,9 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         elif name == "numba_gpu":
             import numpy as xp
             from numba import cuda
-            self.tensor_types = (xp.ndarray, cuda.cudadrv.devicearray.DeviceNDArray)
-            self.native_types = (cuda.cudadrv.devicearray.DeviceNDArray,)
-            self.Tensor = cuda.cudadrv.devicearray.DeviceNDArray
+            self.tensor_types = (xp.ndarray, cuda.cudadrv.devicearray.DeviceNDArray) # pylint: disable=no-member
+            self.native_types = (cuda.cudadrv.devicearray.DeviceNDArray,) # pylint: disable=no-member
+            self.Tensor = cuda.cudadrv.devicearray.DeviceNDArray # pylint: disable=no-member
             if self._numba_gpu_engine is None:
                 from qibojit.custom_operators.backends import NumbaGPUBackend
                 self._numba_gpu_engine = NumbaGPUBackend()

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -387,7 +387,7 @@ class NumbaGPUBackend(NumbaBackend):
         self.ops = cu_ops
         self.np = np
         self.cuda = cuda
-        self.device_array = self.cuda.cudadrv.devicearray.DeviceNDArray
+        self.device_array = self.cuda.cudadrv.devicearray.DeviceNDArray # pylint: disable=no-member
 
         self.multi_qubit_kernels = {
             3: self.gates.apply_three_qubit_gate_kernel,

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -438,7 +438,7 @@ class NumbaGPUBackend(NumbaBackend):
 
     def one_qubit_base(self, state, nqubits, target, kernel, qubits=-1, gate=0):
         # Same as CPU
-        ncontrols = len(qubits) - 1 if qubits != -1 else 0
+        ncontrols = len(qubits) - 1 if not isinstance(qubits, int) else 0
         m = nqubits - target - 1
         nstates = 1 << (nqubits - ncontrols - 1)
 
@@ -458,7 +458,7 @@ class NumbaGPUBackend(NumbaBackend):
 
     def two_qubit_base(self, state, nqubits, target1, target2, kernel, qubits=-1, gate=0):
         # Same as CPU
-        ncontrols = len(qubits) - 2 if qubits != -1 else 0
+        ncontrols = len(qubits) - 2 if not isinstance(qubits, int) else 0
         if target1 > target2:
             swap_targets = True
             m1 = nqubits - target1 - 1

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -414,11 +414,9 @@ class NumbaGPUBackend(NumbaBackend):
             return self.cuda.to_device(x)
         # We need to cast on host memory and then move to device memory
         else:
-            try:
-                dev_x = self.cuda.device_array(x.shape, dtype=dtype)
-            except AttributeError:
-                dev_x = self.cuda.device_array(len(x), dtype=dtype)
-            self.cuda.to_device(self.np.array(x, dtype=dtype), to=dev_x)
+            np_x = self.np.array(x, dtype=dtype)
+            dev_x = self.cuda.device_array(np_x.shape, dtype=dtype)
+            self.cuda.to_device(np_x, to=dev_x)
             return dev_x
 
 

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from qibo.config import raise_error
+
 
 class AbstractBackend(ABC):
 
@@ -357,6 +359,178 @@ class CupyBackend(AbstractBackend): # pragma: no cover
         if normalize:
             norm = self.cp.sqrt(self.cp.sum(self.cp.square(self.cp.abs(state))))
             state = state / norm
+        return state
+
+    def transpose_state(self, pieces, state, nqubits, order):
+        raise NotImplementedError("`transpose_state` method is not "
+                                  "implemented for GPU.")
+
+    def swap_pieces(self, piece0, piece1, new_global, nlocal):
+        raise NotImplementedError("`swap_pieces` method is not "
+                                  "implemented for GPU.")
+
+    def measure_frequencies(self, frequencies, probs, nshots, nqubits, seed=1234, nthreads=None):
+        raise NotImplementedError("`measure_frequencies` method is not "
+                                  "implemented for GPU.")
+
+
+class NumbaGPUBackend(NumbaBackend):
+
+    DEFAULT_BLOCK_SIZE = 64
+
+    def __init__(self):
+        import numpy as np
+        from numba import cuda
+        from qibojit.custom_operators import cu_gates, cu_ops
+        self.name = "numba_gpu"
+        self.gates = cu_gates
+        self.ops = cu_ops
+        self.np = np
+        self.cuda = cuda
+        self.device_array = self.cuda.cudadrv.devicearray.DeviceNDArray
+
+        self.multi_qubit_kernels = {
+            3: self.gates.apply_three_qubit_gate_kernel,
+            4: self.gates.apply_four_qubit_gate_kernel,
+            5: self.gates.apply_five_qubit_gate_kernel
+            }
+
+        try:
+            if not cuda.is_available(): # pragma: no cover
+                raise RuntimeError("Cannot use numba_gpu backend if GPU is not available.")
+        except:
+            raise ImportError("Could not detect compatible GPUs.")
+
+
+    def cast(self, x, dtype=None):
+        # If it's already in device, don't do anything
+        if isinstance(x, self.device_array):
+            if dtype == x.dtype:
+                return x
+            else:
+                raise_error(NotImplementedError)
+        # If no dtype is specified, move x to the device memory
+        if dtype is None:
+            return self.cuda.to_device(x)
+        # We need to cast on host memory and then move to device memory
+        else:
+            try:
+                dev_x = self.cuda.device_array(x.shape, dtype=dtype)
+            except AttributeError:
+                dev_x = self.cuda.device_array(len(x), dtype=dtype)
+            self.cuda.to_device(self.np.array(x, dtype=dtype), to=dev_x)
+            return dev_x
+
+
+    def calculate_blocks(self, nstates, block_size=DEFAULT_BLOCK_SIZE):
+        """Compute the number of blocks and of threads per block.
+
+        The total number of threads is always equal to ``nstates``, give that
+        the kernels are designed to execute only one out of ``nstates`` updates.
+        Therefore, the number of threads per block (``block_size``) changes also
+        the total number of blocks. By default, it is set to ``self.DEFAULT_BLOCK_SIZE``.
+        """
+        # Compute the number of blocks so that at least ``nstates`` threads are launched
+        nblocks = (nstates + block_size - 1) // block_size
+        if nstates < block_size:
+            nblocks = 1
+            block_size = nstates
+        return nblocks, block_size
+
+
+    def one_qubit_base(self, state, nqubits, target, kernel, qubits=-1, gate=0):
+        # Same as CPU
+        ncontrols = len(qubits) - 1 if qubits != -1 else 0
+        m = nqubits - target - 1
+        nstates = 1 << (nqubits - ncontrols - 1)
+
+        # GPU specific operations
+        nblocks, block_size = self.calculate_blocks(nstates)
+
+        # Launch the kernel
+        if ncontrols:
+            kernel = getattr(self.gates, "multicontrol_{}_kernel".format(kernel))
+            kernel[nblocks, block_size](state, gate, qubits, nstates, m)
+        else:
+            kernel = getattr(self.gates, "{}_kernel".format(kernel))
+            kernel[nblocks, block_size](state, gate, nstates, m)
+        self.cuda.synchronize()
+        return state
+
+
+    def two_qubit_base(self, state, nqubits, target1, target2, kernel, qubits=-1, gate=0):
+        # Same as CPU
+        ncontrols = len(qubits) - 2 if qubits != -1 else 0
+        if target1 > target2:
+            swap_targets = True
+            m1 = nqubits - target1 - 1
+            m2 = nqubits - target2 - 1
+        else:
+            swap_targets = False
+            m1 = nqubits - target2 - 1
+            m2 = nqubits - target1 - 1
+        nstates = 1 << (nqubits - 2 - ncontrols)
+
+        # GPU specific operations
+        nblocks, block_size = self.calculate_blocks(nstates)
+
+        # Launch the kernel
+        if ncontrols:
+            kernel = getattr(self.gates, "multicontrol_{}_kernel".format(kernel))
+            kernel[nblocks, block_size](state, gate, qubits, nstates, m1, m2, swap_targets)
+        else:
+            kernel = getattr(self.gates, "{}_kernel".format(kernel))
+            kernel[nblocks, block_size](state, gate, nstates, m1, m2, swap_targets)
+        self.cuda.synchronize()
+        return state
+
+    def multi_qubit_base(self, state, nqubits, targets, qubits=None, gate=0):
+        # Same as CPU
+        if qubits is None:
+            qubits = self.np.array(sorted(nqubits - q - 1 for q in targets), dtype="int32")
+        nstates = 1 << (nqubits - len(qubits))
+        targets = self.np.array([1 << (nqubits - t - 1) for t in targets[::-1]], dtype="int64")
+
+        # GPU specific operations
+        nblocks, block_size = self.calculate_blocks(nstates)
+
+        # Launch the kernel
+        if len(targets) > 5:
+            buffer = self.cuda.to_device(state)
+            kernel = self.gates.apply_multi_qubit_gate_kernel
+            kernel[nblocks, block_size](state, buffer, gate, qubits, targets)
+        else:
+            kernel = self.multi_qubit_kernels.get(len(targets))
+            kernel[nblocks, block_size](state, gate, qubits, targets)
+        self.cuda.synchronize()
+        return state
+
+    def initial_state(self, nqubits, dtype, is_matrix=False):
+        # Same as CPU
+        if isinstance(dtype, str):
+            dtype = getattr(self.np, dtype)
+        size = 2 ** nqubits
+
+        # GPU specific operations + kernel launch
+        nblocks, block_size = self.calculate_blocks(size)
+        if is_matrix:
+            state = self.cuda.device_array((size, size), dtype=dtype)
+            self.ops.initial_density_matrix[nblocks, block_size](state)
+        else:
+            state = self.cuda.device_array((size,), dtype=dtype)
+            self.ops.initial_state[nblocks, block_size](state)
+        self.cuda.synchronize()
+        return state
+
+    def collapse_state(self, state, qubits, result, nqubits, normalize=False):
+        # Same as CPU
+        ntargets = len(qubits)
+        nstates = 1 << (nqubits - ntargets)
+
+        # GPU specific operations + kernel launch
+        nblocks, block_size = self.calculate_blocks(nstates)
+        self.ops.collapse_state_kernel[nblocks, block_size](state, qubits, result, ntargets)
+        self.cuda.synchronize()
         return state
 
     def transpose_state(self, pieces, state, nqubits, order):

--- a/src/qibojit/custom_operators/cu_gates.py
+++ b/src/qibojit/custom_operators/cu_gates.py
@@ -1,5 +1,8 @@
+# pylint: disable=too-many-function-args
+
 from numba import cuda
 import numpy as np
+
 
 @cuda.jit(device=True)
 def multicontrol_index(g, qubits):

--- a/src/qibojit/custom_operators/cu_gates.py
+++ b/src/qibojit/custom_operators/cu_gates.py
@@ -1,0 +1,295 @@
+from numba import cuda
+import numpy as np
+
+@cuda.jit(device=True)
+def multicontrol_index(g, qubits):
+    i = g
+    for n in qubits:
+        k = 1 << n
+        i = ((i >> n) << (n + 1)) + (i & (k - 1)) + k
+    return i
+
+
+@cuda.jit
+def apply_gate_kernel(state, gate, nstates, m):
+    tk = 1 << m
+    g = cuda.grid(1)
+    i1 = ((g >> m) << (m + 1)) + (g & (tk - 1))
+    i2 = i1 + tk
+    state[i1], state[i2] = (gate[0, 0] * state[i1] + gate[0, 1] * state[i2],
+                            gate[1, 0] * state[i1] + gate[1, 1] * state[i2])
+
+
+@cuda.jit
+def multicontrol_apply_gate_kernel(state, gate, qubits, nstates, m):
+    tk = 1 << m
+    g = cuda.grid(1)
+    i = multicontrol_index(g, qubits)
+    i1, i2 = i - tk, i
+    state[i1], state[i2] = (gate[0, 0] * state[i1] + gate[0, 1] * state[i2],
+                            gate[1, 0] * state[i1] + gate[1, 1] * state[i2])
+
+
+@cuda.jit
+def apply_x_kernel(state, gate, nstates, m):
+    tk = 1 << m
+    g = cuda.grid(1)
+    i1 = ((g >> m) << (m + 1)) + (g & (tk - 1))
+    i2 = i1 + tk
+    state[i1], state[i2] = state[i2], state[i1]
+
+
+@cuda.jit
+def multicontrol_apply_x_kernel(state, gate, qubits, nstates, m):
+    tk = 1 << m
+    g = cuda.grid(1)
+    i = multicontrol_index(g, qubits)
+    i1, i2 = i - tk, i
+    state[i1], state[i2] = state[i2], state[i1]
+
+
+@cuda.jit
+def apply_y_kernel(state, gate, nstates, m):
+    tk = 1 << m
+    g = cuda.grid(1)
+    i1 = ((g >> m) << (m + 1)) + (g & (tk - 1))
+    i2 = i1 + tk
+    state[i1], state[i2] = -1j * state[i2], 1j * state[i1]
+
+
+@cuda.jit
+def multicontrol_apply_y_kernel(state, gate, qubits, nstates, m):
+    tk = 1 << m
+    g = cuda.grid(1)
+    i = multicontrol_index(g, qubits)
+    i1, i2 = i - tk, i
+    state[i1], state[i2] = -1j * state[i2], 1j * state[i1]
+
+
+@cuda.jit
+def apply_z_kernel(state, gate, nstates, m):
+    tk = 1 << m
+    g = cuda.grid(1)
+    i = ((g >> m) << (m + 1)) + (g & (tk - 1))
+    state[i + tk] *= -1
+
+
+@cuda.jit
+def multicontrol_apply_z_kernel(state, gate, qubits, nstates, m):
+    tk = 1 << m
+    g = cuda.grid(1)
+    i = multicontrol_index(g, qubits)
+    state[i] *= -1
+
+
+@cuda.jit
+def apply_z_pow_kernel(state, gate, nstates, m):
+    tk = 1 << m
+    g = cuda.grid(1)
+    i = ((g >> m) << (m + 1)) + (g & (tk - 1))
+    state[i + tk] = gate * state[i + tk]
+
+
+@cuda.jit
+def multicontrol_apply_z_pow_kernel(state, gate, qubits, nstates, m):
+    tk = 1 << m
+    g = cuda.grid(1)
+    i = multicontrol_index(g, qubits)
+    state[i] = gate * state[i]
+
+
+@cuda.jit
+def apply_two_qubit_gate_kernel(state, gate, nstates, m1, m2, swap_targets=False):
+    tk1, tk2 = 1 << m1, 1 << m2
+    uk1, uk2 = tk1, tk2
+    if swap_targets:
+        uk1, uk2 = uk2, uk1
+    g = cuda.grid(1)
+    i = ((g >> m1) << (m1 + 1)) + (g & (tk1 - 1))
+    i = ((i >> m2) << (m2 + 1)) + (i & (tk2 - 1))
+    i1, i2 = i + uk1, i + uk2
+    i3 = i + tk1 + tk2
+    buffer0, buffer1, buffer2 = state[i], state[i1], state[i2]
+    state[i] = (gate[0, 0] * state[i] + gate[0, 1] * state[i1] +
+                gate[0, 2] * state[i2] + gate[0, 3] * state[i3])
+    state[i1] = (gate[1, 0] * buffer0 + gate[1, 1] * state[i1] +
+                 gate[1, 2] * state[i2] + gate[1, 3] * state[i3])
+    state[i2] = (gate[2, 0] * buffer0 + gate[2, 1] * buffer1 +
+                 gate[2, 2] * state[i2] + gate[2, 3] * state[i3])
+    state[i3] = (gate[3, 0] * buffer0 + gate[3, 1] * buffer1 +
+                 gate[3, 2] * buffer2 + gate[3, 3] * state[i3])
+
+
+@cuda.jit
+def multicontrol_apply_two_qubit_gate_kernel(state, gate, qubits, nstates, m1, m2, swap_targets=False):
+    tk1, tk2 = 1 << m1, 1 << m2
+    uk1, uk2 = tk1, tk2
+    if swap_targets:
+        uk1, uk2 = uk2, uk1
+    g = cuda.grid(1)
+    i = multicontrol_index(g, qubits)
+    i1, i2 = i - uk2, i - uk1
+    i0 = i1 - uk1
+    buffer0, buffer1, buffer2 = state[i0], state[i1], state[i2]
+    state[i0] = (gate[0, 0] * state[i0] + gate[0, 1] * state[i1] +
+                 gate[0, 2] * state[i2] + gate[0, 3] * state[i])
+    state[i1] = (gate[1, 0] * buffer0 + gate[1, 1] * state[i1] +
+                 gate[1, 2] * state[i2] + gate[1, 3] * state[i])
+    state[i2] = (gate[2, 0] * buffer0 + gate[2, 1] * buffer1 +
+                 gate[2, 2] * state[i2] + gate[2, 3] * state[i])
+    state[i] = (gate[3, 0] * buffer0 + gate[3, 1] * buffer1 +
+                gate[3, 2] * buffer2 + gate[3, 3] * state[i])
+
+
+@cuda.jit
+def apply_swap_kernel(state, gate, nstates, m1, m2, swap_targets=False):
+    tk1, tk2 = 1 << m1, 1 << m2
+    g = cuda.grid(1)
+    i = ((g >> m1) << (m1 + 1)) + (g & (tk1 - 1))
+    i = ((i >> m2) << (m2 + 1)) + (i & (tk2 - 1))
+    i1, i2 = i + tk1, i + tk2
+    state[i1], state[i2] = state[i2], state[i1]
+
+
+@cuda.jit
+def multicontrol_apply_swap_kernel(state, gate, qubits, nstates, m1, m2, swap_targets=False):
+    tk1, tk2 = 1 << m1, 1 << m2
+    uk1, uk2 = tk1, tk2
+    g = cuda.grid(1)
+    i = multicontrol_index(g, qubits)
+    i1, i2 = i - tk2, i - tk1
+    state[i1], state[i2] = state[i2], state[i1]
+
+
+@cuda.jit
+def apply_fsim_kernel(state, gate, nstates, m1, m2, swap_targets=False):
+    tk1, tk2 = 1 << m1, 1 << m2
+    uk1, uk2 = tk1, tk2
+    if swap_targets:
+        uk1, uk2 = uk2, uk1
+    g = cuda.grid(1)
+    i = ((g >> m1) << (m1 + 1)) + (g & (tk1 - 1))
+    i = ((i >> m2) << (m2 + 1)) + (i & (tk2 - 1))
+    i1, i2 = i + uk1, i + uk2
+    i3 = i + tk1 + tk2
+    state[i1], state[i2] = (gate[0] * state[i1] + gate[1] * state[i2],
+                            gate[2] * state[i1] + gate[3] * state[i2])
+    state[i3] *= gate[4]
+
+
+@cuda.jit
+def multicontrol_apply_fsim_kernel(state, gate, qubits, nstates, m1, m2, swap_targets=False):
+    tk1, tk2 = 1 << m1, 1 << m2
+    uk1, uk2 = tk1, tk2
+    if swap_targets:
+        uk1, uk2 = uk2, uk1
+    g = cuda.grid(1)
+    i = multicontrol_index(g, qubits)
+    i1, i2 = i - uk2, i - uk1
+    state[i1], state[i2] = (gate[0] * state[i1] + gate[1] * state[i2],
+                            gate[2] * state[i1] + gate[3] * state[i2])
+    state[i] *= gate[4]
+
+@cuda.jit(device=True)
+def multitarget_index(i, targets):
+    t = 0
+    for u, v in enumerate(targets):
+        t += ((i >> u) & 1) * v
+    return t
+
+
+@cuda.jit
+def apply_three_qubit_gate_kernel(state, gate, qubits, targets):
+    g = cuda.grid(1)
+    ig = multicontrol_index(g, qubits)
+    buffer0 = state[ig - targets[0] - targets[1] - targets[2]]
+    buffer1 = state[ig - targets[1] - targets[2]]
+    buffer2 = state[ig - targets[0] - targets[2]]
+    buffer3 = state[ig - targets[2]]
+    buffer4 = state[ig - targets[0] - targets[1]]
+    buffer5 = state[ig - targets[1]]
+    buffer6 = state[ig - targets[0]]
+    buffer7 = state[ig]
+    for i in range(8):
+        t = ig - multitarget_index(7 - i, targets)
+        state[t] = gate[i, 0] * buffer0 + gate[i, 1] * buffer1 + gate[i, 2] * buffer2 + gate[i, 3] * buffer3 + gate[i, 4] * buffer4 + gate[i, 5] * buffer5 + gate[i, 6] * buffer6 + gate[i, 7] * buffer7
+
+
+@cuda.jit
+def apply_four_qubit_gate_kernel(state, gate, qubits, targets):
+    g = cuda.grid(1)
+    ig = multicontrol_index(g, qubits)
+    buffer0 = state[ig - targets[0] - targets[1] - targets[2] - targets[3]]
+    buffer1 = state[ig - targets[1] - targets[2] - targets[3]]
+    buffer2 = state[ig - targets[0] - targets[2] - targets[3]]
+    buffer3 = state[ig - targets[2] - targets[3]]
+    buffer4 = state[ig - targets[0] - targets[1] - targets[3]]
+    buffer5 = state[ig - targets[1] - targets[3]]
+    buffer6 = state[ig - targets[0] - targets[3]]
+    buffer7 = state[ig - targets[3]]
+    buffer8 = state[ig - targets[0] - targets[1] - targets[2]]
+    buffer9 = state[ig - targets[1] - targets[2]]
+    buffer10 = state[ig - targets[0] - targets[2]]
+    buffer11 = state[ig - targets[2]]
+    buffer12 = state[ig - targets[0] - targets[1]]
+    buffer13 = state[ig - targets[1]]
+    buffer14 = state[ig - targets[0]]
+    buffer15 = state[ig]
+    for i in range(16):
+        t = ig - multitarget_index(15 - i, targets)
+        state[t] = gate[i, 0] * buffer0 + gate[i, 1] * buffer1 + gate[i, 2] * buffer2 + gate[i, 3] * buffer3 + gate[i, 4] * buffer4 + gate[i, 5] * buffer5 + gate[i, 6] * buffer6 + gate[i, 7] * buffer7 + gate[i, 8] * buffer8 + gate[i, 9] * buffer9 + gate[i, 10] * buffer10 + gate[i, 11] * buffer11 + gate[i, 12] * buffer12 + gate[i, 13] * buffer13 + gate[i, 14] * buffer14 + gate[i, 15] * buffer15
+
+
+@cuda.jit
+def apply_five_qubit_gate_kernel(state, gate, qubits, targets):
+    g = cuda.grid(1)
+    ig = multicontrol_index(g, qubits)
+    buffer0 = state[ig - targets[0] - targets[1] - targets[2] - targets[3] - targets[4]]
+    buffer1 = state[ig - targets[1] - targets[2] - targets[3] - targets[4]]
+    buffer2 = state[ig - targets[0] - targets[2] - targets[3] - targets[4]]
+    buffer3 = state[ig - targets[2] - targets[3] - targets[4]]
+    buffer4 = state[ig - targets[0] - targets[1] - targets[3] - targets[4]]
+    buffer5 = state[ig - targets[1] - targets[3] - targets[4]]
+    buffer6 = state[ig - targets[0] - targets[3] - targets[4]]
+    buffer7 = state[ig - targets[3] - targets[4]]
+    buffer8 = state[ig - targets[0] - targets[1] - targets[2] - targets[4]]
+    buffer9 = state[ig - targets[1] - targets[2] - targets[4]]
+    buffer10 = state[ig - targets[0] - targets[2] - targets[4]]
+    buffer11 = state[ig - targets[2] - targets[4]]
+    buffer12 = state[ig - targets[0] - targets[1] - targets[4]]
+    buffer13 = state[ig - targets[1] - targets[4]]
+    buffer14 = state[ig - targets[0] - targets[4]]
+    buffer15 = state[ig - targets[4]]
+    buffer16 = state[ig - targets[0] - targets[1] - targets[2] - targets[3]]
+    buffer17 = state[ig - targets[1] - targets[2] - targets[3]]
+    buffer18 = state[ig - targets[0] - targets[2] - targets[3]]
+    buffer19 = state[ig - targets[2] - targets[3]]
+    buffer20 = state[ig - targets[0] - targets[1] - targets[3]]
+    buffer21 = state[ig - targets[1] - targets[3]]
+    buffer22 = state[ig - targets[0] - targets[3]]
+    buffer23 = state[ig - targets[3]]
+    buffer24 = state[ig - targets[0] - targets[1] - targets[2]]
+    buffer25 = state[ig - targets[1] - targets[2]]
+    buffer26 = state[ig - targets[0] - targets[2]]
+    buffer27 = state[ig - targets[2]]
+    buffer28 = state[ig - targets[0] - targets[1]]
+    buffer29 = state[ig - targets[1]]
+    buffer30 = state[ig - targets[0]]
+    buffer31 = state[ig]
+    for i in range(32):
+        t = ig - multitarget_index(31 - i, targets)
+        state[t] = gate[i, 0] * buffer0 + gate[i, 1] * buffer1 + gate[i, 2] * buffer2 + gate[i, 3] * buffer3 + gate[i, 4] * buffer4 + gate[i, 5] * buffer5 + gate[i, 6] * buffer6 + gate[i, 7] * buffer7 + gate[i, 8] * buffer8 + gate[i, 9] * buffer9 + gate[i, 10] * buffer10 + gate[i, 11] * buffer11 + gate[i, 12] * buffer12 + gate[i, 13] * buffer13 + gate[i, 14] * buffer14 + gate[i, 15] * buffer15 + gate[i, 16] * buffer16 + gate[i, 17] * buffer17 + gate[i, 18] * buffer18 + gate[i, 19] * buffer19 + gate[i, 20] * buffer20 + gate[i, 21] * buffer21 + gate[i, 22] * buffer22 + gate[i, 23] * buffer23 + gate[i, 24] * buffer24 + gate[i, 25] * buffer25 + gate[i, 26] * buffer26 + gate[i, 27] * buffer27 + gate[i, 28] * buffer28 + gate[i, 29] * buffer29 + gate[i, 30] * buffer30 + gate[i, 31] * buffer31
+
+
+@cuda.jit
+def apply_multi_qubit_gate_kernel(state, gate, qubits, targets):
+    nsubstates = 1 << len(targets)
+    g = cuda.grid(1)
+    ig = multicontrol_index(g, qubits)
+    buffer = np.empty(nsubstates, dtype=state.dtype)
+    for i in range(nsubstates):
+        t = ig - multitarget_index(nsubstates - i - 1, targets)
+        buffer[i] = state[t]
+    for i in range(nsubstates):
+        t = ig - multitarget_index(nsubstates - i - 1, targets)
+        state[t] = np.dot(gate[i], buffer)

--- a/src/qibojit/custom_operators/cu_gates.py
+++ b/src/qibojit/custom_operators/cu_gates.py
@@ -90,7 +90,7 @@ def apply_z_pow_kernel(state, gate, nstates, m):
     tk = 1 << m
     g = cuda.grid(1)
     i = ((g >> m) << (m + 1)) + (g & (tk - 1))
-    state[i + tk] = gate * state[i + tk]
+    state[i + tk] = gate[()] * state[i + tk]
 
 
 @cuda.jit
@@ -98,7 +98,7 @@ def multicontrol_apply_z_pow_kernel(state, gate, qubits, nstates, m):
     tk = 1 << m
     g = cuda.grid(1)
     i = multicontrol_index(g, qubits)
-    state[i] = gate * state[i]
+    state[i] = gate[()] * state[i]
 
 
 @cuda.jit

--- a/src/qibojit/custom_operators/cu_ops.py
+++ b/src/qibojit/custom_operators/cu_ops.py
@@ -1,4 +1,7 @@
+# pylint: disable=too-many-function-args
+
 from numba import cuda
+
 
 @cuda.jit
 def initial_density_matrix(state):

--- a/src/qibojit/custom_operators/cu_ops.py
+++ b/src/qibojit/custom_operators/cu_ops.py
@@ -1,0 +1,38 @@
+from numba import cuda
+
+@cuda.jit
+def initial_density_matrix(state):
+    id = cuda.grid(1)
+    for index in range(len(state)):
+        state[id, index] = 0
+    state[0, 0] = 1
+
+
+@cuda.jit
+def initial_state(state):
+    id = cuda.grid(1)
+    if id == 0:
+        state[id] = 1
+    else:
+        state[id] = 0
+
+
+@cuda.jit(device=True)
+def collapse_index(g, h, qubits):
+    i = g
+    for j, n in enumerate(qubits):
+        k = 1 << n
+        i = ((i >> n) << (n + 1)) + (i & (k - 1)) + ((h >> j) % 2) * k
+    return i
+
+
+@cuda.jit
+def collapse_state_kernel(state, qubits, result, nqubits):
+    nsubstates = 1 << len(qubits)
+
+    g = cuda.grid(1)
+    for h in range(result):
+        state[collapse_index(g, h, qubits)] = 0
+    for h in range(result + 1, nsubstates):
+        state[collapse_index(g, h, qubits)] = 0
+

--- a/src/qibojit/tests/conftest.py
+++ b/src/qibojit/tests/conftest.py
@@ -7,6 +7,9 @@ _BACKENDS = ["numba"]
 if K._cupy_engine is not None:  # pragma: no cover
     # CI does not test for GPU
     _BACKENDS.append("cupy")
+if K._numba_gpu_engine is not None:  # pragma: no cover
+    # CI does not test for GPU
+    _BACKENDS.append("numba_gpu")
 
 
 @pytest.fixture

--- a/src/qibojit/tests/test_ops.py
+++ b/src/qibojit/tests/test_ops.py
@@ -36,7 +36,8 @@ def test_backends_initial_state(backend, dtype, is_matrix):
 @pytest.mark.parametrize("nqubits,targets,results",
                          [(2, [0], [1]), (2, [1], [0]), (3, [1], [1]),
                           (4, [1, 3], [1, 0]), (5, [1, 2, 4], [0, 1, 1]),
-                          (15, [4, 7], [0, 0]), (16, [8, 12, 15], [1, 0, 1])])
+                          (15, [4, 7], [0, 0]), (16, [8, 12, 15], [1, 0, 1]),
+                          (20, [1, 2, 4, 9, 19], [0, 0, 1, 1, 1])])
 @pytest.mark.parametrize("normalize", [False, True])
 def test_collapse_state(backend, nqubits, targets, results, normalize, dtype):
     atol = 1e-7 if dtype == "complex64" else 1e-14
@@ -170,7 +171,7 @@ def test_swap_pieces(nqubits, qlocal, qglobal, dtype):
 def test_measure_frequencies(backend, realtype, inttype, nthreads):
     probs = np.ones(16, dtype=realtype) / 16
     frequencies = np.zeros(16, dtype=inttype)
-    if K.engine.name == "cupy":  # pragma: no cover
+    if K.engine.name in ("cupy", "numba_gpu"):  # pragma: no cover
         # CI does not test for GPU
         with pytest.raises(NotImplementedError):
             frequencies = K.engine.measure_frequencies(frequencies, probs, nshots=1000,


### PR DESCRIPTION
In this PR I implemented a GPU backend that uses Numba. The goal is to assess its performance and see if it may be a good alternative to Cupy.

This new backend is only a partial implementation, as the density matrix calls are still to be fixed. Moreover, some operations are not supported (e.g. arithmetic operations between a device array and and int or float numbers in host code). This breaks some functionalities of Qibo, but we can still run benchmarks.

As always fine-tuning may change these results, but Cupy seems faster, with a substantial advantage in circuits with a small number of qubits. Numba, instead, has a smaller compilation overhead. Note that for this benchmark I deactivated the compilation during the import (for cupy). EDIT: for both cupy and numba I used 1024 threads per block.

<details><summary> qft </summary>

nqubits | Simulation time cupy | Simulation time numba_gpu | Dry run overhead cupy | Dry run overhead numba_gpu
-- | -- | -- | -- | --
3 | 0.00038 | 0.00085 | 0.9151764750480652 | 0.39372308254241944
4 | 0.00061 | 0.00132 | 0.9182806253433228 | 0.22470632791519166
5 | 0.00088 | 0.00180 | 0.9194815993309021 | 0.22513166666030884
6 | 0.00119 | 0.00245 | 0.9178803920745849 | 0.22589269876480103
7 | 0.00155 | 0.00314 | 0.9203890085220336 | 0.22932177782058716
8 | 0.00209 | 0.00397 | 0.9176576495170593 | 0.22936758995056153
9 | 0.00254 | 0.00474 | 0.9229723453521729 | 0.23387645483016967
10 | 0.00299 | 0.00573 | 0.9197258353233337 | 0.23524923324584962
11 | 0.00380 | 0.00688 | 0.9223066568374634 | 0.2391204357147217
12 | 0.00455 | 0.00801 | 0.9196613073348999 | 0.24190555810928344
13 | 0.00508 | 0.00963 | 0.922712767124176 | 0.24445995092391967
14 | 0.00599 | 0.01076 | 0.923897922039032 | 0.24830663204193115
15 | 0.00684 | 0.01181 | 0.9168319225311279 | 0.25066194534301756
16 | 0.00779 | 0.01375 | 0.9255693435668946 | 0.25664674043655394
17 | 0.00865 | 0.01540 | 0.9193841457366944 | 0.25849658250808716
18 | 0.01021 | 0.01706 | 0.9206625461578369 | 0.2662771582603455
19 | 0.01165 | 0.01940 | 0.9283653974533081 | 0.270539379119873
20 | 0.01474 | 0.02163 | 0.9286629796028137 | 0.2747878789901733
21 | 0.02116 | 0.02864 | 0.9329722881317138 | 0.2743494987487793
22 | 0.03240 | 0.04036 | 0.9313127994537354 | 0.2810977458953857
23 | 0.05469 | 0.06387 | 0.9304193496704102 | 0.287307071685791
24 | 0.10079 | 0.11123 | 0.9303715705871582 | 0.29200992584228513
25 | 0.19675 | 0.20855 | 0.9393755912780761 | 0.29770574569702146
26 | 0.40241 | 0.41607 | 0.9422370910644531 | 0.30370230674743653
27 | 0.83491 | 0.85256 | 0.9445147037506103 | 0.3073667049407959
28 | 1.75634 | 1.77792 | 0.937534475326538 | 0.311820888519287
29 | 3.69874 | 3.73336 | 0.9295771598815916 | 0.3057109355926513
30 | 7.82428 | 7.89393 | 0.9280393600463865 | 0.2857973575592041

</details>

<details><summary> variational </summary>

nqubits | Simulation time cupy | Simulation time numba_gpu | Dry run overhead cupy | Dry run overhead numba_gpu
-- | -- | -- | -- | --
3 | 0.00033 | 0.00092 | 0.9150363087654114 | 0.22908270359039307
4 | 0.00046 | 0.00129 | 0.9197784900665283 | 0.1870747208595276
5 | 0.00052 | 0.00144 | 0.9180811166763305 | 0.1875584363937378
6 | 0.00067 | 0.00181 | 0.9185503363609314 | 0.18921416997909546
7 | 0.00071 | 0.00201 | 0.9182541370391846 | 0.1906563401222229
8 | 0.00084 | 0.00237 | 0.9137699723243713 | 0.19081240892410278
9 | 0.00093 | 0.00255 | 0.9161326646804809 | 0.19328233003616332
10 | 0.00109 | 0.00287 | 0.9196553349494934 | 0.19483915567398072
11 | 0.00125 | 0.00309 | 0.917859923839569 | 0.19484854936599733
12 | 0.00138 | 0.00346 | 0.9205231308937073 | 0.19646294116973878
13 | 0.00146 | 0.00369 | 0.9118951082229614 | 0.1988992929458618
14 | 0.00163 | 0.00400 | 0.9169878005981446 | 0.19912371635437012
15 | 0.00166 | 0.00410 | 0.918331241607666 | 0.19701597690582276
16 | 0.00183 | 0.00463 | 0.9174162983894348 | 0.20104413032531737
17 | 0.00196 | 0.00486 | 0.9211397647857666 | 0.20119340419769288
18 | 0.00222 | 0.00538 | 0.9172272682189941 | 0.20273176431655884
19 | 0.00300 | 0.00609 | 0.9149930238723755 | 0.20416228771209716
20 | 0.00427 | 0.00745 | 0.9210782289505005 | 0.20260899066925048
21 | 0.00686 | 0.01060 | 0.9215971469879151 | 0.20592575073242186
22 | 0.01225 | 0.01668 | 0.9182041645050049 | 0.20579996109008789
23 | 0.02296 | 0.02772 | 0.9179378986358643 | 0.20579948425292968
24 | 0.04586 | 0.05155 | 0.9217719078063965 | 0.2065950393676758
25 | 0.09224 | 0.09876 | 0.9224301338195801 | 0.2060943603515625
26 | 0.19064 | 0.19917 | 0.9178159713745118 | 0.20902915000915528
27 | 0.38908 | 0.40134 | 0.9189221858978271 | 0.20647945404052737
28 | 0.81006 | 0.82714 | 0.9233675956726074 | 0.20700583457946775
29 | 1.65995 | 1.69524 | 0.9113995552062988 | 0.19528136253356942
30 | 3.45581 | 3.52614 | 0.9119315624237059 | 0.17198967933654785

</details>

<details><summary> supremacy </summary>

nqubits | Simulation time cupy | Simulation time numba_gpu | Dry run overhead cupy | Dry run overhead numba_gpu
-- | -- | -- | -- | --
3 | 0.00040 | 0.00108 | 0.9176580905914307 | 0.27566167116165163
4 | 0.00052 | 0.00137 | 0.9113833189010621 | 0.28220831155776976
5 | 0.00064 | 0.00166 | 0.9142333269119263 | 0.279436194896698
6 | 0.00074 | 0.00204 | 0.9112993955612183 | 0.282186484336853
7 | 0.00087 | 0.00225 | 0.9120476841926575 | 0.28242557048797606
8 | 0.00100 | 0.00249 | 0.9143061161041259 | 0.2817721128463745
9 | 0.00110 | 0.00279 | 0.9137215971946716 | 0.28554747104644773
10 | 0.00133 | 0.00317 | 0.9120726585388184 | 0.283611798286438
11 | 0.00151 | 0.00347 | 0.9124491095542908 | 0.286725652217865
12 | 0.00166 | 0.00375 | 0.9178303599357605 | 0.2862760066986084
13 | 0.00176 | 0.00399 | 0.9218409419059753 | 0.28840529918670654
14 | 0.00193 | 0.00426 | 0.9154765367507934 | 0.2936093330383301
15 | 0.00206 | 0.00483 | 0.9136180758476258 | 0.2893231511116028
16 | 0.00216 | 0.00495 | 0.9176264524459838 | 0.29177074432373046
17 | 0.00228 | 0.00544 | 0.914232587814331 | 0.29025317430496217
18 | 0.00280 | 0.00579 | 0.9172996520996094 | 0.29468594789505004
19 | 0.00373 | 0.00673 | 0.9167650580406189 | 0.294001567363739
20 | 0.00536 | 0.00848 | 0.9170765042304992 | 0.29374865293502805
21 | 0.00857 | 0.01238 | 0.9198744297027588 | 0.296476411819458
22 | 0.01543 | 0.02003 | 0.9161161422729492 | 0.29425773620605467
23 | 0.02923 | 0.03409 | 0.9173520088195801 | 0.2934697151184082
24 | 0.05768 | 0.06308 | 0.9222365856170655 | 0.2961618423461914
25 | 0.11734 | 0.12410 | 0.9197750568389893 | 0.29944143295288084
26 | 0.24299 | 0.25171 | 0.9249423980712891 | 0.2987250328063965
27 | 0.49692 | 0.50981 | 0.9189109802246094 | 0.29301977157592773
28 | 1.02467 | 1.04238 | 0.9177283287048339 | 0.29071445465087886
29 | 2.11942 | 2.15624 | 0.9144937992095947 | 0.28010339736938494
30 | 4.41276 | 4.48546 | 0.9086195945739748 | 0.2575901508331295


</details>

<details><summary> bv </summary>

nqubits | Simulation time cupy | Simulation time numba_gpu | Dry run overhead cupy | Dry run overhead numba_gpu
-- | -- | -- | -- | --
3 | 0.00032 | 0.00093 | 0.9139754295349121 | 0.3507705569267273
4 | 0.00041 | 0.00121 | 0.9115342020988464 | 0.22122472524642944
5 | 0.00051 | 0.00146 | 0.914733064174652 | 0.22314796447753907
6 | 0.00062 | 0.00172 | 0.9129144430160523 | 0.22320787906646727
7 | 0.00071 | 0.00199 | 0.9078160285949707 | 0.22330312728881835
8 | 0.00081 | 0.00225 | 0.9152618408203125 | 0.2229264497756958
9 | 0.00090 | 0.00254 | 0.9098666787147522 | 0.225579571723938
10 | 0.00105 | 0.00281 | 0.911300265789032 | 0.22629990577697753
11 | 0.00122 | 0.00305 | 0.9165602326393127 | 0.22596946954727173
12 | 0.00138 | 0.00337 | 0.9166404366493225 | 0.22831435203552247
13 | 0.00145 | 0.00354 | 0.9150871872901917 | 0.22561317682266235
14 | 0.00154 | 0.00395 | 0.9260912299156189 | 0.22945905923843385
15 | 0.00167 | 0.00418 | 0.919365406036377 | 0.2293491005897522
16 | 0.00180 | 0.00439 | 0.9197435140609741 | 0.2288865327835083
17 | 0.00191 | 0.00485 | 0.9181190609931946 | 0.23270596265792848
18 | 0.00219 | 0.00537 | 0.9156004905700683 | 0.2308575391769409
19 | 0.00307 | 0.00608 | 0.9218876481056213 | 0.23130202293395996
20 | 0.00450 | 0.00760 | 0.9182038068771362 | 0.23100180625915528
21 | 0.00733 | 0.01105 | 0.9204535007476806 | 0.23305702209472656
22 | 0.01308 | 0.01767 | 0.9231822490692139 | 0.23313617706298828
23 | 0.02499 | 0.02984 | 0.9191287517547607 | 0.23281116485595704
24 | 0.04978 | 0.05538 | 0.9155448913574219 | 0.23374557495117188
25 | 0.10107 | 0.10794 | 0.9192240715026856 | 0.23277368545532226
26 | 0.20784 | 0.21690 | 0.9138583660125732 | 0.23343496322631835
27 | 0.42845 | 0.44144 | 0.9158064842224121 | 0.22987332344055178
28 | 0.88517 | 0.90415 | 0.9168127059936524 | 0.23018059730529783
29 | 1.82972 | 1.86796 | 0.9208312034606934 | 0.2157127857208252
30 | 3.78194 | 3.86051 | 0.9319783210754395 | 0.19238963127136222

</details>

<details><summary> qv </summary>

nqubits | Simulation time cupy | Simulation time numba_gpu | Dry run overhead cupy | Dry run overhead numba_gpu
-- | -- | -- | -- | --
3 | 0.00043 | 0.00121 | 0.918164074420929 | 0.23456774950027465
4 | 0.00077 | 0.00213 | 0.9135611414909363 | 0.19359103441238404
5 | 0.00080 | 0.00217 | 0.9190158128738404 | 0.1949317216873169
6 | 0.00116 | 0.00314 | 0.918745243549347 | 0.1980982542037964
7 | 0.00122 | 0.00320 | 0.9178489446640015 | 0.201424241065979
8 | 0.00154 | 0.00417 | 0.917098069190979 | 0.20440617799758912
9 | 0.00163 | 0.00410 | 0.9172372579574585 | 0.20315908193588256
10 | 0.00202 | 0.00507 | 0.9184269189834595 | 0.20798860788345336
11 | 0.00217 | 0.00518 | 0.9266609072685241 | 0.2086155652999878
12 | 0.00252 | 0.00611 | 0.9215991616249084 | 0.21337292194366456
13 | 0.00261 | 0.00634 | 0.9198028922080994 | 0.21415339708328246
14 | 0.00305 | 0.00716 | 0.9234309792518616 | 0.21626044511795045
15 | 0.00313 | 0.00728 | 0.9193844795227051 | 0.219775390625
16 | 0.00346 | 0.00828 | 0.9214813590049744 | 0.22230437994003296
17 | 0.00350 | 0.00819 | 0.9205222845077514 | 0.22081170082092286
18 | 0.00436 | 0.00969 | 0.9216543436050415 | 0.22643284797668456
19 | 0.00564 | 0.01031 | 0.9230634093284606 | 0.22503520250320436
20 | 0.00882 | 0.01366 | 0.922971248626709 | 0.22885727882385254
21 | 0.01343 | 0.01895 | 0.9241061687469483 | 0.22834982872009277
22 | 0.02547 | 0.03212 | 0.9267126083374023 | 0.32801294326782227
23 | 0.04640 | 0.05347 | 0.9259225368499756 | 0.32662138938903806
24 | 0.09506 | 0.10307 | 0.9291239261627198 | 0.3327006816864014
25 | 0.18773 | 0.19687 | 0.9264794826507569 | 0.33083815574645997
26 | 0.39634 | 0.40834 | 0.9251072406768799 | 0.33890252113342284
27 | 0.79671 | 0.81265 | 0.9206322193145752 | 0.332155704498291
28 | 1.70813 | 1.72997 | 0.9240665435791016 | 0.3364196300506592
29 | 3.37052 | 3.41272 | 0.9188987255096435 | 0.323496437072754
30 | 7.29080 | 7.37778 | 0.9191365242004395 | 0.29671454429626465


</details>
