### PR TITLE
Fix multiqubit GPU ops not called by JitCustomBackend

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -331,13 +331,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return self.engine.two_qubit_base(state, nqubits, *targets, "apply_fsim", qubits, gate)
 
     def apply_multi_qubit_gate(self, state, gate, nqubits, targets, qubits=None):
-        # FIXME: fall back to numba temporarily until we implement this for GPU
-        state = self.to_numpy(state)
-        gate = self.to_numpy(gate)
-        targets = self.to_numpy(targets)
-        if qubits is not None:
-            qubits = self.to_numpy(qubits)
-        return self._numba_engine.multi_qubit_base(state, nqubits, targets, qubits, gate)
+        return self.engine.multi_qubit_base(state, nqubits, targets, qubits, gate)
 
     def collapse_state(self, state, qubits, result, nqubits, normalize=True):
         return self.engine.collapse_state(state, qubits, result, nqubits, normalize)

--- a/src/qibojit/custom_operators/gates.py
+++ b/src/qibojit/custom_operators/gates.py
@@ -283,7 +283,9 @@ def apply_three_qubit_gate_kernel(state, gate, qubits, nstates, targets):
         buffer7 = state[ig]
         for i in range(8):
             t = ig - multitarget_index(7 - i, targets)
-            state[t] = gate[i, 0] * buffer0 + gate[i, 1] * buffer1 + gate[i, 2] * buffer2 + gate[i, 3] * buffer3 + gate[i, 4] * buffer4 + gate[i, 5] * buffer5 + gate[i, 6] * buffer6 + gate[i, 7] * buffer7
+            state[t] = gate[i, 0] * buffer0 + gate[i, 1] * buffer1 + gate[i, 2] * buffer2 \
+                     + gate[i, 3] * buffer3 + gate[i, 4] * buffer4 + gate[i, 5] * buffer5 \
+                     + gate[i, 6] * buffer6 + gate[i, 7] * buffer7
     return state
 
 
@@ -294,16 +296,16 @@ def apply_three_qubit_gate_kernel(state, gate, qubits, nstates, targets):
 def apply_four_qubit_gate_kernel(state, gate, qubits, nstates, targets):
     for g in prange(nstates):  # pylint: disable=not-an-iterable
         ig = multicontrol_index(g, qubits)
-        buffer0 = state[ig - targets[0] - targets[1] - targets[2] - targets[3]]
-        buffer1 = state[ig - targets[1] - targets[2] - targets[3]]
-        buffer2 = state[ig - targets[0] - targets[2] - targets[3]]
-        buffer3 = state[ig - targets[2] - targets[3]]
-        buffer4 = state[ig - targets[0] - targets[1] - targets[3]]
-        buffer5 = state[ig - targets[1] - targets[3]]
-        buffer6 = state[ig - targets[0] - targets[3]]
-        buffer7 = state[ig - targets[3]]
-        buffer8 = state[ig - targets[0] - targets[1] - targets[2]]
-        buffer9 = state[ig - targets[1] - targets[2]]
+        buffer0  = state[ig - targets[0] - targets[1] - targets[2] - targets[3]]
+        buffer1  = state[ig - targets[1] - targets[2] - targets[3]]
+        buffer2  = state[ig - targets[0] - targets[2] - targets[3]]
+        buffer3  = state[ig - targets[2] - targets[3]]
+        buffer4  = state[ig - targets[0] - targets[1] - targets[3]]
+        buffer5  = state[ig - targets[1] - targets[3]]
+        buffer6  = state[ig - targets[0] - targets[3]]
+        buffer7  = state[ig - targets[3]]
+        buffer8  = state[ig - targets[0] - targets[1] - targets[2]]
+        buffer9  = state[ig - targets[1] - targets[2]]
         buffer10 = state[ig - targets[0] - targets[2]]
         buffer11 = state[ig - targets[2]]
         buffer12 = state[ig - targets[0] - targets[1]]
@@ -312,7 +314,12 @@ def apply_four_qubit_gate_kernel(state, gate, qubits, nstates, targets):
         buffer15 = state[ig]
         for i in range(16):
             t = ig - multitarget_index(15 - i, targets)
-            state[t] = gate[i, 0] * buffer0 + gate[i, 1] * buffer1 + gate[i, 2] * buffer2 + gate[i, 3] * buffer3 + gate[i, 4] * buffer4 + gate[i, 5] * buffer5 + gate[i, 6] * buffer6 + gate[i, 7] * buffer7 + gate[i, 8] * buffer8 + gate[i, 9] * buffer9 + gate[i, 10] * buffer10 + gate[i, 11] * buffer11 + gate[i, 12] * buffer12 + gate[i, 13] * buffer13 + gate[i, 14] * buffer14 + gate[i, 15] * buffer15
+            state[t] = gate[i, 0]  * buffer0  + gate[i, 1]  * buffer1  + gate[i, 2]  * buffer2  \
+                     + gate[i, 3]  * buffer3  + gate[i, 4]  * buffer4  + gate[i, 5]  * buffer5  \
+                     + gate[i, 6]  * buffer6  + gate[i, 7]  * buffer7  + gate[i, 8]  * buffer8  \
+                     + gate[i, 9]  * buffer9  + gate[i, 10] * buffer10 + gate[i, 11] * buffer11 \
+                     + gate[i, 12] * buffer12 + gate[i, 13] * buffer13 + gate[i, 14] * buffer14 \
+                     + gate[i, 15] * buffer15
     return state
 
 
@@ -323,16 +330,16 @@ def apply_four_qubit_gate_kernel(state, gate, qubits, nstates, targets):
 def apply_five_qubit_gate_kernel(state, gate, qubits, nstates, targets):
     for g in prange(nstates):  # pylint: disable=not-an-iterable
         ig = multicontrol_index(g, qubits)
-        buffer0 = state[ig - targets[0] - targets[1] - targets[2] - targets[3] - targets[4]]
-        buffer1 = state[ig - targets[1] - targets[2] - targets[3] - targets[4]]
-        buffer2 = state[ig - targets[0] - targets[2] - targets[3] - targets[4]]
-        buffer3 = state[ig - targets[2] - targets[3] - targets[4]]
-        buffer4 = state[ig - targets[0] - targets[1] - targets[3] - targets[4]]
-        buffer5 = state[ig - targets[1] - targets[3] - targets[4]]
-        buffer6 = state[ig - targets[0] - targets[3] - targets[4]]
-        buffer7 = state[ig - targets[3] - targets[4]]
-        buffer8 = state[ig - targets[0] - targets[1] - targets[2] - targets[4]]
-        buffer9 = state[ig - targets[1] - targets[2] - targets[4]]
+        buffer0  = state[ig - targets[0] - targets[1] - targets[2] - targets[3] - targets[4]]
+        buffer1  = state[ig - targets[1] - targets[2] - targets[3] - targets[4]]
+        buffer2  = state[ig - targets[0] - targets[2] - targets[3] - targets[4]]
+        buffer3  = state[ig - targets[2] - targets[3] - targets[4]]
+        buffer4  = state[ig - targets[0] - targets[1] - targets[3] - targets[4]]
+        buffer5  = state[ig - targets[1] - targets[3] - targets[4]]
+        buffer6  = state[ig - targets[0] - targets[3] - targets[4]]
+        buffer7  = state[ig - targets[3] - targets[4]]
+        buffer8  = state[ig - targets[0] - targets[1] - targets[2] - targets[4]]
+        buffer9  = state[ig - targets[1] - targets[2] - targets[4]]
         buffer10 = state[ig - targets[0] - targets[2] - targets[4]]
         buffer11 = state[ig - targets[2] - targets[4]]
         buffer12 = state[ig - targets[0] - targets[1] - targets[4]]
@@ -357,7 +364,17 @@ def apply_five_qubit_gate_kernel(state, gate, qubits, nstates, targets):
         buffer31 = state[ig]
         for i in range(32):
             t = ig - multitarget_index(31 - i, targets)
-            state[t] = gate[i, 0] * buffer0 + gate[i, 1] * buffer1 + gate[i, 2] * buffer2 + gate[i, 3] * buffer3 + gate[i, 4] * buffer4 + gate[i, 5] * buffer5 + gate[i, 6] * buffer6 + gate[i, 7] * buffer7 + gate[i, 8] * buffer8 + gate[i, 9] * buffer9 + gate[i, 10] * buffer10 + gate[i, 11] * buffer11 + gate[i, 12] * buffer12 + gate[i, 13] * buffer13 + gate[i, 14] * buffer14 + gate[i, 15] * buffer15 + gate[i, 16] * buffer16 + gate[i, 17] * buffer17 + gate[i, 18] * buffer18 + gate[i, 19] * buffer19 + gate[i, 20] * buffer20 + gate[i, 21] * buffer21 + gate[i, 22] * buffer22 + gate[i, 23] * buffer23 + gate[i, 24] * buffer24 + gate[i, 25] * buffer25 + gate[i, 26] * buffer26 + gate[i, 27] * buffer27 + gate[i, 28] * buffer28 + gate[i, 29] * buffer29 + gate[i, 30] * buffer30 + gate[i, 31] * buffer31
+            state[t] = gate[i, 0]  * buffer0  + gate[i, 1]  * buffer1  + gate[i, 2]  * buffer2  \
+                     + gate[i, 3]  * buffer3  + gate[i, 4]  * buffer4  + gate[i, 5]  * buffer5  \
+                     + gate[i, 6]  * buffer6  + gate[i, 7]  * buffer7  + gate[i, 8]  * buffer8  \
+                     + gate[i, 9]  * buffer9  + gate[i, 10] * buffer10 + gate[i, 11] * buffer11 \
+                     + gate[i, 12] * buffer12 + gate[i, 13] * buffer13 + gate[i, 14] * buffer14 \
+                     + gate[i, 15] * buffer15 + gate[i, 16] * buffer16 + gate[i, 17] * buffer17 \
+                     + gate[i, 18] * buffer18 + gate[i, 19] * buffer19 + gate[i, 20] * buffer20 \
+                     + gate[i, 21] * buffer21 + gate[i, 22] * buffer22 + gate[i, 23] * buffer23 \
+                     + gate[i, 24] * buffer24 + gate[i, 25] * buffer25 + gate[i, 26] * buffer26 \
+                     + gate[i, 27] * buffer27 + gate[i, 28] * buffer28 + gate[i, 29] * buffer29 \
+                     + gate[i, 30] * buffer30 + gate[i, 31] * buffer31
     return state
 
 


### PR DESCRIPTION
It looks like we forgot to update the call to the multiqubit GPU kernels in ``JitCustomBackend`` after we moved the latter from qibo to qibojit.