### PR TITLE
Fix ``CupyBackend`` crash with 32 qubits

### DIFF
--- a/src/qibojit/custom_operators/gates.cu.cc
+++ b/src/qibojit/custom_operators/gates.cu.cc
@@ -11,7 +11,7 @@ __device__ long multicontrol_index(const int* qubits, long g, int ncontrols) {
   long i = g;
   for (int iq = 0; iq < ncontrols; iq++) {
       const int n = qubits[iq];
-      long k = (long)(1 << n);
+      long k = ((long)1 << n);
       i = ((long)((long)i >> n) << (n + 1)) + (i & (k - 1)) + k;
   }
   return i;

--- a/src/qibojit/custom_operators/gates.cu.cc
+++ b/src/qibojit/custom_operators/gates.cu.cc
@@ -320,7 +320,7 @@ __device__ long collapse_index(const int* qubits, long g, long h, int ntargets) 
     const auto n = qubits[iq];
     long k = (long)1 << n;
     i = ((long)((long)i >> n) << (n + 1)) + (i & (k - 1));
-    i += ((long)((int)(h >> iq) % 2) * k);
+    i += ((long)((long)(h >> iq) % 2) * k);
   }
   return i;
 }


### PR DESCRIPTION
If I run a circuit with 32 qubits on GPU with the ``CupyBackend`` I get the following error:
```
 File ".../qibojit/src/qibojit/custom_operators/backends.py", line 261, in one_qubit_base
    self.cp.cuda.stream.get_current_stream().synchronize()
  File "cupy/cuda/stream.pyx", line 221, in cupy.cuda.stream.BaseStream.synchronize
  File "cupy_backends/cuda/api/runtime.pyx", line 894, in cupy_backends.cuda.api.runtime.streamSynchronize
  File "cupy_backends/cuda/api/runtime.pyx", line 273, in cupy_backends.cuda.api.runtime.check_status
cupy_backends.cuda.api.runtime.CUDARuntimeError: cudaErrorIllegalAddress: an illegal memory access was encountered
```

The problem is solved after fixing a cast from long to int in line 14 of ``gates.cu.cc``:
```
(long)(1 << n) -> ((long)1 << n)
```

Let me know if you agree.