### PR TITLE
Fix CPU fallback

### DIFF
--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -61,7 +61,9 @@ class NumbaBackend(AbstractBackend):
         if not isinstance(x, self.np.ndarray):
             try:
                 x = self.np.array(x)
-            except TypeError: # only for CuPy arrays
+            # only for CuPy arrays, as implicit conversion raises TypeError
+            # and you need to cast manually using x.get()
+            except TypeError: # pragma: no cover
                 x = x.get()
         if dtype and x.dtype != dtype:
             return x.astype(dtype)

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -59,7 +59,10 @@ class NumbaBackend(AbstractBackend):
 
     def cast(self, x, dtype=None):
         if not isinstance(x, self.np.ndarray):
-            x = self.np.array(x)
+            try:
+                x = self.np.array(x)
+            except TypeError: # only for CuPy arrays
+                x = x.get()
         if dtype and x.dtype != dtype:
             return x.astype(dtype)
         return x


### PR DESCRIPTION
Closes #46. Linked PR in qibo repository:

The CPU fallback for some methods is not working properly. In order to fix it, we need to change the corresponding method in qibo, however we need NumbaBackend to be able to cast from CuPy arrays to Numpy ones.

As it is now, it is not possible because ``self.np.array(x)`` raises a ``TypeError``  if ``x`` is a CuPy array. We cannot check easily if ``x`` is a CuPy array because NumbaBackend is independent of CuPy.

As a temporary fix, I tried to catch a ``TypeError``, I don't know if this solution is optimal. @stavros11 what do you think?