### PR TITLE
Implement a custom CPU fallback for qibojit

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -296,7 +296,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
             return func(*args)
         except self.oom_error: # pragma: no cover
             # case not covered by GitHub workflows because it requires OOM
-            log.warn("Falling back to CPU because the GPU is out-of-memory.")
+            log.warn(f"Falling back to CPU for {func.__name__} because the GPU is out-of-memory.")
             # Make sure to convert all CuPy arrays to NumPy ones
             args = [item.get() if isinstance(item, self.Tensor) else item for item in args]
             with self.device(self.get_cpu()):

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -296,7 +296,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
             return func(*args)
         except self.oom_error: # pragma: no cover
             # case not covered by GitHub workflows because it requires OOM
-            log.warn(f"Falling back to CPU for {func.__name__} because the GPU is out-of-memory.")
+            log.warn(f"Falling back to CPU for '{func.__name__}' because the GPU is out-of-memory.")
             # Make sure to convert all CuPy arrays to NumPy ones
             args = [item.get() if isinstance(item, self.Tensor) else item for item in args]
             with self.device(self.get_cpu()):

--- a/src/qibojit/tests/test_backends.py
+++ b/src/qibojit/tests/test_backends.py
@@ -91,3 +91,7 @@ def test_with_device(backend):
 def test_cpu_ops(backend):
     with K.on_cpu():
         pass
+
+
+def test_cpu_fallback(backend):
+    state = K.cpu_fallback(K.initial_state, 4)


### PR DESCRIPTION
In some circumstances the CPU fallback for qibojit does not work. Here we ensure that all the arguments are properly converted from CuPy arrays to Numpy ones, so that the fallback does not fail.