### PR TITLE
Fix cast method not changing dtype

### DIFF
--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -58,16 +58,19 @@ class NumbaBackend(AbstractBackend):
             }
 
     def cast(self, x, dtype=None):
-        if not isinstance(x, self.np.ndarray):
+        if isinstance(x, self.np.ndarray):
+            if dtype is None:
+                return x
+            else:
+                return x.astype(dtype, copy=False)
+        else:
             try:
-                x = self.np.array(x)
+                x = self.np.array(x, dtype=dtype)
             # only for CuPy arrays, as implicit conversion raises TypeError
             # and you need to cast manually using x.get()
             except TypeError: # pragma: no cover
-                x = x.get()
-        if dtype and x.dtype != dtype:
-            return x.astype(dtype)
-        return x
+                x = self.np.array(x.get(), dtype=dtype, copy=False)
+            return x
 
     def one_qubit_base(self, state, nqubits, target, kernel, qubits=None, gate=None):
         ncontrols = len(qubits) - 1 if qubits is not None else 0
@@ -232,7 +235,10 @@ class CupyBackend(AbstractBackend): # pragma: no cover
 
     def cast(self, x, dtype=None):
         if isinstance(x, self.cp.ndarray):
-            return x
+            if dtype is None:
+                return x
+            else:
+                return x.astype(dtype, copy=False)
         return self.cp.asarray(x, dtype=dtype)
 
     def get_kernel_type(self, state):


### PR DESCRIPTION
Closes #47. While working to fix #47, I noticed that PR https://github.com/qiboteam/qibo/pull/528 do not resolve the problem with qibojit.

In fact, the cast method of CuPy doesn't change the dtype if the input array is already a CuPy array. I fixed it, and I also make some additional changes to improve the cast for both CuPy and Numba, because some times the dtype is ignored. Let me know your opinion.