### PR TITLE
Adding CuQuantum library

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -52,7 +52,10 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         if self.gpu_devices: # pragma: no cover
             # CI does not use GPUs
             self.default_device = self.gpu_devices[0]
-            self.set_engine("cupy")
+            if os.environ.get("ENABLE_CUQUANTUM", False):
+                self.set_engine("cuquantum")
+            else:
+                self.set_engine("cupy")
         elif self.cpu_devices:
             self.default_device = self.cpu_devices[0]
             self.set_engine("numba")

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -10,14 +10,13 @@ class CupyCpuDevice:  # pragma: no cover
 
     def __init__(self, K):
         self.K = K
-        self.original_engine = K.engine.name
 
     def __enter__(self, *args):
         self.K.set_engine("numba")
 
     def __exit__(self, *args):
         if self.K.gpu_devices:
-            self.K.set_engine(self.original_engine)
+            self.K.set_engine("cupy")
 
 
 class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
@@ -25,7 +24,6 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
     description = "Uses custom operators based on numba.jit for CPU and " \
                   "custom CUDA kernels loaded with cupy GPU."
 
-    default_gpu_engine = "cuquantum"
 
     def __init__(self):
         NumpyBackend.__init__(self)
@@ -54,7 +52,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         if self.gpu_devices: # pragma: no cover
             # CI does not use GPUs
             self.default_device = self.gpu_devices[0]
-            self.set_engine(self.default_gpu_engine)
+            self.set_engine("cupy")
         elif self.cpu_devices:
             self.default_device = self.cpu_devices[0]
             self.set_engine("numba")
@@ -111,7 +109,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
     def set_device(self, name):
         AbstractBackend.set_device(self, name)
         if "GPU" in name: # pragma: no cover
-            self.set_engine(self.default_gpu_engine)
+            self.set_engine("cupy")
         else:
             self.set_engine("numba")
 

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -347,7 +347,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return self.engine.one_qubit_base(state, nqubits, *targets, "apply_z", qubits, gate)
 
     def apply_z_pow(self, state, gate, nqubits, targets, qubits=None):
-        if self.engine.name == "cuquantum":
+        if self.engine.name == "cuquantum": # pragma: no cover
             phase = gate
             gate = self.engine.cp.zeros((2, 2),dtype=state.dtype)
             gate[0, 0], gate[1, 1] = 1, phase
@@ -363,7 +363,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return self.engine.two_qubit_base(state, nqubits, *targets, "apply_swap", qubits, gate)
 
     def apply_fsim(self, state, gate, nqubits, targets, qubits=None):
-        if self.engine.name == "cuquantum":
+        if self.engine.name == "cuquantum": # pragma: no cover
             fsimgate = self.engine.cp.zeros((4, 4),dtype=state.dtype)
             fsimgate[0, 0], fsimgate[3,3] = 1, gate[4]
             fsimgate[1,1], fsimgate[1,2] = gate[0], gate[1]

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -22,7 +22,7 @@ class CupyCpuDevice:  # pragma: no cover
 class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
 
     description = "Uses custom operators based on numba.jit for CPU and " \
-                  "custom CUDA kernels loaded with cupy GPU."
+                  "custom CUDA kernels loaded with cupy or CuQuantum for GPU."
 
 
     def __init__(self):
@@ -74,7 +74,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return NumpyBackend.test_regressions(self, name)
 
     def set_engine(self, name): # pragma: no cover
-        """Switcher between ``cupy`` for GPU and ``numba`` for CPU."""
+        """Switcher between ``cupy`` and ``cuquantum`` for GPU and ``numba`` for CPU."""
         if name == "numba":
             import numpy as xp
             self.tensor_types = (xp.ndarray,)
@@ -151,7 +151,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return super().ones(self.check_shape(shape), dtype=dtype)
 
     def expm(self, x):
-        if self.engine.name == "cupy": # pragma: no cover
+        if self.engine.name in ["cupy", "cuquantum"]: # pragma: no cover
             # Fallback to numpy because cupy does not have expm
             if isinstance(x, self.native_types):
                 x = x.get()
@@ -172,14 +172,14 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return super().eigvalsh(x)
 
     def unique(self, x, return_counts=False):
-        if self.engine.name == "cupy":  # pragma: no cover
+        if self.engine.name in ["cupy", "cuquantum"]:  # pragma: no cover
             if isinstance(x, self.native_types):
                 x = x.get()
             # Uses numpy backend always
         return super().unique(x, return_counts)
 
     def gather(self, x, indices=None, condition=None, axis=0):
-        if self.engine.name == "cupy":  # pragma: no cover
+        if self.engine.name in ["cupy", "cuquantum"]:  # pragma: no cover
             # Fallback to numpy because cupy does not support tuple indexing
             if isinstance(x, self.native_types):
                 x = x.get()

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -12,11 +12,12 @@ class CupyCpuDevice:  # pragma: no cover
         self.K = K
 
     def __enter__(self, *args):
+        self.original_engine = K.engine.name
         self.K.set_engine("numba")
 
     def __exit__(self, *args):
         if self.K.gpu_devices:
-            self.K.set_engine("cupy")
+            self.K.set_engine(self.original_engine)
 
 
 class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
@@ -52,10 +53,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         if self.gpu_devices: # pragma: no cover
             # CI does not use GPUs
             self.default_device = self.gpu_devices[0]
-            if os.environ.get("ENABLE_CUQUANTUM", False):
-                self.set_engine("cuquantum")
-            else:
-                self.set_engine("cupy")
+            self.set_engine(os.environ.get("GPU_ENGINE", "cupy"))
         elif self.cpu_devices:
             self.default_device = self.cpu_devices[0]
             self.set_engine("numba")

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -12,7 +12,9 @@ class CupyCpuDevice:  # pragma: no cover
         self.K = K
 
     def __enter__(self, *args):
-        self.original_engine = self.K.engine.name
+        name = self.K.engine.name
+        if name != "numba":
+            self.original_engine = name
         self.K.set_engine("numba")
 
     def __exit__(self, *args):

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -12,7 +12,7 @@ class CupyCpuDevice:  # pragma: no cover
         self.K = K
 
     def __enter__(self, *args):
-        self.original_engine = K.engine.name
+        self.original_engine = self.K.engine.name
         self.K.set_engine("numba")
 
     def __exit__(self, *args):

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -321,7 +321,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return self.reshape(state, original_shape)
 
     def assert_allclose(self, value, target, rtol=1e-7, atol=0.0):
-        if self.engine.name == "cupy": # pragma: no cover
+        if self.engine.name in ["cupy", "cuquantum"]: # pragma: no cover
             if isinstance(value, self.backend.ndarray):
                 value = value.get()
             if isinstance(target, self.backend.ndarray):

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -331,19 +331,13 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return self.engine.one_qubit_base(state, nqubits, *targets, "apply_gate", qubits, gate)
 
     def apply_x(self, state, nqubits, targets, qubits=None):
-        # cast necessary to avoid numba error (missing signature with state complex 64 and gate complex128)
-        gate = self.engine.cast(self.matrices.X, dtype=state.dtype)
-        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_x", qubits, gate)
+        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_x", qubits, self.matrices.X)
 
     def apply_y(self, state, nqubits, targets, qubits=None):
-        # cast necessary to avoid numba error (missing signature with state complex 64 and gate complex128)
-        gate = self.engine.cast(self.matrices.Y, dtype=state.dtype)
-        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_y", qubits, gate)
+        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_y", qubits, self.matrices.Y)
 
     def apply_z(self, state, nqubits, targets, qubits=None):
-        # cast necessary to avoid numba error (missing signature with state complex 64 and gate complex128)
-        gate = self.engine.cast(self.matrices.Z, dtype=state.dtype)
-        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_z", qubits, gate)
+        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_z", qubits, self.matrices.Z)
 
     def apply_z_pow(self, state, gate, nqubits, targets, qubits=None):
         if self.engine.name == "cuquantum": # pragma: no cover
@@ -357,9 +351,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
                                           qubits, gate)
 
     def apply_swap(self, state, nqubits, targets, qubits=None):
-        # cast necessary to avoid numba error (missing signature with state complex 64 and gate complex128)
-        gate = self.engine.cast(self.matrices.SWAP, dtype=state.dtype)
-        return self.engine.two_qubit_base(state, nqubits, *targets, "apply_swap", qubits, gate)
+        return self.engine.two_qubit_base(state, nqubits, *targets, "apply_swap", qubits, self.matrices.SWAP)
 
     def apply_fsim(self, state, gate, nqubits, targets, qubits=None):
         if self.engine.name == "cuquantum": # pragma: no cover

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -330,30 +330,30 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         self.np.testing.assert_allclose(value, target, rtol=rtol, atol=atol)
 
     def apply_gate(self, state, gate, nqubits, targets, qubits=None):
-        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_gate", qubits, gate)
+        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_gate", gate, qubits)
 
     def apply_x(self, state, nqubits, targets, qubits=None):
-        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_x", qubits, self.matrices.X)
+        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_x", self.matrices.X, qubits)
 
     def apply_y(self, state, nqubits, targets, qubits=None):
-        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_y", qubits, self.matrices.Y)
+        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_y", self.matrices.Y, qubits)
 
     def apply_z(self, state, nqubits, targets, qubits=None):
-        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_z", qubits, self.matrices.Z)
+        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_z", self.matrices.Z, qubits)
 
     def apply_z_pow(self, state, gate, nqubits, targets, qubits=None):
         if self.engine.name == "cuquantum": # pragma: no cover
             phase = gate
             gate = self.engine.cp.zeros((2, 2),dtype=state.dtype)
             gate[0, 0], gate[1, 1] = 1, phase
-        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_z_pow", qubits, gate)
+        return self.engine.one_qubit_base(state, nqubits, *targets, "apply_z_pow", gate, qubits)
 
     def apply_two_qubit_gate(self, state, gate, nqubits, targets, qubits=None):
         return self.engine.two_qubit_base(state, nqubits, *targets, "apply_two_qubit_gate",
-                                          qubits, gate)
+                                          gate, qubits)
 
     def apply_swap(self, state, nqubits, targets, qubits=None):
-        return self.engine.two_qubit_base(state, nqubits, *targets, "apply_swap", qubits, self.matrices.SWAP)
+        return self.engine.two_qubit_base(state, nqubits, *targets, "apply_swap", self.matrices.SWAP, qubits)
 
     def apply_fsim(self, state, gate, nqubits, targets, qubits=None):
         if self.engine.name == "cuquantum": # pragma: no cover
@@ -362,10 +362,10 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
             fsimgate[1,1], fsimgate[1,2] = gate[0], gate[1]
             fsimgate[2,1], fsimgate[2,2] = gate[2], gate[3]
             gate = fsimgate
-        return self.engine.two_qubit_base(state, nqubits, *targets, "apply_fsim", qubits, gate)
+        return self.engine.two_qubit_base(state, nqubits, *targets, "apply_fsim", gate, qubits)
 
     def apply_multi_qubit_gate(self, state, gate, nqubits, targets, qubits=None):
-        return self.engine.multi_qubit_base(state, nqubits, targets, qubits, gate)
+        return self.engine.multi_qubit_base(state, nqubits, targets, gate, qubits)
 
     def collapse_state(self, state, qubits, result, nqubits, normalize=True):
         return self.engine.collapse_state(state, qubits, result, nqubits, normalize)

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -389,7 +389,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
     # CI does not test for GPU
 
     def __init__(self):
-        super(CuQuantumBackend, self).__init__()
+        super().__init__()
         import cuquantum # pylint: disable=import-error
         from cuquantum import custatevec as cusv # pylint: disable=import-error
         self.cuquantum = cuquantum 
@@ -440,18 +440,17 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         else:
             raise ValueError
 
-        args1 = (handle,
-                 data_type,
-                 nqubits,
-                 gate_ptr,
-                 data_type,
-                 self.cusv.MatrixLayout.ROW,
-                 adjoint,
-                 ntarget,
-                 ncontrols,
-                 compute_type
-                 )
-        workspaceSize = self.cusv.apply_matrix_buffer_size(*args1)
+        workspaceSize = self.cusv.apply_matrix_buffer_size(handle,
+                                                           data_type,
+                                                           nqubits,
+                                                           gate_ptr,
+                                                           data_type,
+                                                           self.cusv.MatrixLayout.ROW,
+                                                           adjoint,
+                                                           ntarget,
+                                                           ncontrols,
+                                                           compute_type
+                                                           )
 
         # check the size of external workspace
         if workspaceSize > 0:
@@ -460,25 +459,24 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         else:
             workspace_ptr = 0
 
-        args2 = (handle,
-                 state.data.ptr,
-                 data_type,
-                 nqubits,
-                 gate_ptr,
-                 data_type,
-                 self.cusv.MatrixLayout.ROW,
-                 adjoint,
-                 target.ctypes.data,
-                 ntarget,
-                 controls.ctypes.data,
-                 ncontrols,
-                 0,
-                 compute_type,
-                 workspace_ptr,
-                 workspaceSize
-                 )
+        self.cusv.apply_matrix(handle,
+                               state.data.ptr,
+                               data_type,
+                               nqubits,
+                               gate_ptr,
+                               data_type,
+                               self.cusv.MatrixLayout.ROW,
+                               adjoint,
+                               target.ctypes.data,
+                               ntarget,
+                               controls.ctypes.data,
+                               ncontrols,
+                               0,
+                               compute_type,
+                               workspace_ptr,
+                               workspaceSize
+                               )
 
-        self.cusv.apply_matrix(*args2)
         self.cusv.destroy(handle)
         return state
 
@@ -517,18 +515,17 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         else:
             raise ValueError
 
-        args1 = (handle,
-                 data_type,
-                 nqubits,
-                 gate_ptr,
-                 data_type,
-                 self.cusv.MatrixLayout.ROW,
-                 adjoint,
-                 ntarget,
-                 ncontrols,
-                 compute_type
-                 )
-        workspaceSize = self.cusv.apply_matrix_buffer_size(*args1)
+        workspaceSize = self.cusv.apply_matrix_buffer_size(handle,
+                                                           data_type,
+                                                           nqubits,
+                                                           gate_ptr,
+                                                           data_type,
+                                                           self.cusv.MatrixLayout.ROW,
+                                                           adjoint,
+                                                           ntarget,
+                                                           ncontrols,
+                                                           compute_type
+                                                           )
 
         # check the size of external workspace
         if workspaceSize > 0:
@@ -537,24 +534,24 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         else:
             workspace_ptr = 0
 
-        args2 = (handle,
-                 state.data.ptr,
-                 data_type,
-                 nqubits,
-                 gate_ptr,
-                 data_type,
-                 self.cusv.MatrixLayout.ROW,
-                 adjoint,
-                 target.ctypes.data,
-                 ntarget,
-                 controls.ctypes.data,
-                 ncontrols,
-                 0,
-                 compute_type,
-                 workspace_ptr,
-                 workspaceSize
-                 )
-        self.cusv.apply_matrix(*args2)
+        self.cusv.apply_matrix(handle,
+                               state.data.ptr,
+                               data_type,
+                               nqubits,
+                               gate_ptr,
+                               data_type,
+                               self.cusv.MatrixLayout.ROW,
+                               adjoint,
+                               target.ctypes.data,
+                               ntarget,
+                               controls.ctypes.data,
+                               ncontrols,
+                               0,
+                               compute_type,
+                               workspace_ptr,
+                               workspaceSize
+                               )
+
         self.cusv.destroy(handle)
         return state
 
@@ -580,18 +577,17 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         else:
             raise ValueError
 
-        args1 = (handle,
-                 data_type,
-                 nqubits,
-                 gate_ptr,
-                 data_type,
-                 self.cusv.MatrixLayout.ROW,
-                 adjoint,
-                 ntarget,
-                 ncontrols,
-                 compute_type
-                 )
-        workspaceSize = self.cusv.apply_matrix_buffer_size(*args1)
+        workspaceSize = self.cusv.apply_matrix_buffer_size(handle,
+                                                           data_type,
+                                                           nqubits,
+                                                           gate_ptr,
+                                                           data_type,
+                                                           self.cusv.MatrixLayout.ROW,
+                                                           adjoint,
+                                                           ntarget,
+                                                           ncontrols,
+                                                           compute_type
+                                                           )
 
         # check the size of external workspace
         if workspaceSize > 0:
@@ -600,35 +596,24 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         else:
             workspace_ptr = 0
 
-        args2 = (handle,
-                 state.data.ptr,
-                 data_type,
-                 nqubits,
-                 gate_ptr,
-                 data_type,
-                 self.cusv.MatrixLayout.ROW,
-                 adjoint,
-                 target.ctypes.data,
-                 ntarget,
-                 controls.ctypes.data,
-                 ncontrols,
-                 0,
-                 compute_type,
-                 workspace_ptr,
-                 workspaceSize
-                 )
-        self.cusv.apply_matrix(*args2)
+        self.cusv.apply_matrix(handle,
+                               state.data.ptr,
+                               data_type,
+                               nqubits,
+                               gate_ptr,
+                               data_type,
+                               self.cusv.MatrixLayout.ROW,
+                               adjoint,
+                               target.ctypes.data,
+                               ntarget,
+                               controls.ctypes.data,
+                               ncontrols,
+                               0,
+                               compute_type,
+                               workspace_ptr,
+                               workspaceSize
+                               )
+
         self.cusv.destroy(handle)
         return state
 
-    def transpose_state(self, pieces, state, nqubits, order):
-        raise NotImplementedError("`transpose_state` method is not "
-                                  "implemented for GPU.")
-
-    def swap_pieces(self, piece0, piece1, new_global, nlocal):
-        raise NotImplementedError("`swap_pieces` method is not "
-                                  "implemented for GPU.")
-
-    def measure_frequencies(self, frequencies, probs, nshots, nqubits, seed=1234, nthreads=None):
-        raise NotImplementedError("`measure_frequencies` method is not "
-                                  "implemented for GPU.")

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -392,8 +392,8 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
     def __init__(self):
         super(CuQuantumBackend, self).__init__()
         import cuquantum
-        from cuquantum import custatevec as cusv
-        self.cuquantum = cuquantum
+        from cuquantum import custatevec as cusv # pylint: disable=import-error
+        self.cuquantum = cuquantum # pylint: disable=import-error
         self.cusv = cusv
         self.name = "cuquantum"
 
@@ -430,7 +430,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
 
         # check the size of external workspace
         if workspaceSize > 0:
-            workspace = cp.cuda.memory.alloc(workspaceSize)
+            workspace = self.cp.cuda.memory.alloc(workspaceSize)
             workspace_ptr = workspace.ptr
         else:
             workspace_ptr = 0
@@ -444,7 +444,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
                  self.cusv.MatrixLayout.ROW,
                  adjoint,
                  target.ctypes.data,
-                 0,
+                 1,
                  ncontrols.ctypes.data,
                  ncontrols,
                  0,

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -396,6 +396,14 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         self.cusv = cusv
         self.name = "cuquantum"
 
+    def get_cuda_type(self, dtype='complex64'):
+        if dtype == 'complex128':
+            return self.cuquantum.cudaDataType.CUDA_C_64F, self.cuquantum.ComputeType.COMPUTE_64F
+        elif dtype == 'complex64':
+            return self.cuquantum.cudaDataType.CUDA_C_32F, self.cuquantum.ComputeType.COMPUTE_32F
+        else:
+            raise TypeError("Type can be either complex64 or complex128")
+
     def one_qubit_base(self, state, nqubits, target, kernel, qubits=None, gate=None):
         # initialize cuStateVec library
         handle = self.cusv.create()
@@ -417,8 +425,10 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
             elif kernel == "apply_z":
                 gate[0, 0], gate[1, 1] = 1, -1
 
-        state = self.cast(state, self.np.complex64)
+        state = self.cast(state)
         gate = self.cast(gate)
+        assert state.dtype == gate.dtype
+        data_type, compute_type = self.get_cuda_type(state.dtype)
         if isinstance(gate, self.cp.ndarray):
             gate_ptr = gate.data.ptr
         elif isinstance(gate, self.np.ndarray):
@@ -427,15 +437,15 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
             raise ValueError
 
         args1 = (handle,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  nqubits,
                  gate_ptr,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  self.cusv.MatrixLayout.ROW,
                  adjoint,
                  ntarget,
                  ncontrols,
-                 self.cuquantum.ComputeType.COMPUTE_32F
+                 compute_type
                  )
         workspaceSize = self.cusv.apply_matrix_buffer_size(*args1)
 
@@ -448,10 +458,10 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
 
         args2 = (handle,
                  state.data.ptr,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  nqubits,
                  gate_ptr,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  self.cusv.MatrixLayout.ROW,
                  adjoint,
                  target.ctypes.data,
@@ -459,7 +469,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
                  controls.ctypes.data,
                  ncontrols,
                  0,
-                 self.cuquantum.ComputeType.COMPUTE_32F,
+                 compute_type,
                  workspace_ptr,
                  workspaceSize
                  )
@@ -482,6 +492,9 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
 
         state = self.cast(state)
         gate = self.cast(gate)
+
+        assert state.dtype == gate.dtype
+        data_type, compute_type = self.get_cuda_type(state.dtype)
         if isinstance(gate, self.cp.ndarray):
             gate_ptr = gate.data.ptr
         elif isinstance(gate, self.np.ndarray):
@@ -490,15 +503,15 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
             raise ValueError
 
         args1 = (handle,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  nqubits,
                  gate_ptr,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  self.cusv.MatrixLayout.ROW,
                  adjoint,
                  ntarget,
                  ncontrols,
-                 self.cuquantum.ComputeType.COMPUTE_32F
+                 compute_type
                  )
         workspaceSize = self.cusv.apply_matrix_buffer_size(*args1)
 
@@ -511,10 +524,10 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
 
         args2 = (handle,
                  state.data.ptr,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  nqubits,
                  gate_ptr,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  self.cusv.MatrixLayout.ROW,
                  adjoint,
                  target.ctypes.data,
@@ -522,7 +535,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
                  controls.ctypes.data,
                  ncontrols,
                  0,
-                 self.cuquantum.ComputeType.COMPUTE_32F,
+                 compute_type,
                  workspace_ptr,
                  workspaceSize
                  )
@@ -542,6 +555,9 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         ncontrols = len(controls) if qubits is not None else 0
         adjoint = 0
         gate = self.cast(gate)
+        assert state.dtype == gate.dtype
+        data_type, compute_type = self.get_cuda_type(state.dtype)
+
         if isinstance(gate, self.cp.ndarray):
             gate_ptr = gate.data.ptr
         elif isinstance(gate, self.np.ndarray):
@@ -550,15 +566,15 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
             raise ValueError
 
         args1 = (handle,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  nqubits,
                  gate_ptr,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  self.cusv.MatrixLayout.ROW,
                  adjoint,
                  ntarget,
                  ncontrols,
-                 self.cuquantum.ComputeType.COMPUTE_32F
+                 compute_type
                  )
         workspaceSize = self.cusv.apply_matrix_buffer_size(*args1)
 
@@ -571,10 +587,10 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
 
         args2 = (handle,
                  state.data.ptr,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  nqubits,
                  gate_ptr,
-                 self.cuquantum.cudaDataType.CUDA_C_32F,
+                 data_type,
                  self.cusv.MatrixLayout.ROW,
                  adjoint,
                  target.ctypes.data,
@@ -582,7 +598,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
                  controls.ctypes.data,
                  ncontrols,
                  0,
-                 self.cuquantum.ComputeType.COMPUTE_32F,
+                 compute_type,
                  workspace_ptr,
                  workspaceSize
                  )

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -583,3 +583,15 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         self.cusv.apply_matrix(*args2)
         self.cusv.destroy(handle)
         return state
+
+    def transpose_state(self, pieces, state, nqubits, order):
+        raise NotImplementedError("`transpose_state` method is not "
+                                  "implemented for GPU.")
+
+    def swap_pieces(self, piece0, piece1, new_global, nlocal):
+        raise NotImplementedError("`swap_pieces` method is not "
+                                  "implemented for GPU.")
+
+    def measure_frequencies(self, frequencies, probs, nshots, nqubits, seed=1234, nthreads=None):
+        raise NotImplementedError("`measure_frequencies` method is not "
+                                  "implemented for GPU.")

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -458,10 +458,3 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         self.cusv.destroy(handle)
         return state
 
-    def initial_state(self, nqubits, dtype, is_matrix=False):
-        # cuQuantum doesn't have a kernel for the initial state
-        n = 1 << nqubits
-        state = self.cp.zeros(n, dtype=dtype)
-        state[0] = 1
-        return state
-

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -402,6 +402,16 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         ncontrols = len(qubits) - 1 if qubits is not None else 0
         controls = self.np.asarray([ncontrols], dtype=self.np.int32)
         state = self.cast(state, self.np.complex64)
+        # implement x, y, z and z_pow kernel since cuquantum only has apply_matrix
+        # TODO: find a better way to implement this
+        if gate is None:
+            gate = self.cp.zeros((2, 2))
+            if kernel == "apply_x":
+                gate[0, 1], gate[1, 0] = 1, 1
+            elif kernel == "apply_y":
+                gate[0, 1], gate[1, 0] = -1j, 1j
+            elif kernel == "apply_z":
+                gate[0, 0], gate[1, 1] = 1, -1
         gate = self.cast(gate, self.np.complex64)
         ntarget = 1
         target = self.np.asarray([target], dtype=self.np.int32)
@@ -412,9 +422,6 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
             gate_ptr = gate.ctypes.data
         else:
             raise ValueError
-
-        if gate is None:
-            raise NotImplementedError("Gate must not be None")
 
         args1 = (handle,
                  self.cuquantum.cudaDataType.CUDA_C_32F,

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -416,6 +416,10 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         adjoint = 0
         # implement x, y, z and z_pow kernel since cuquantum only has apply_matrix
         # TODO: find a better way to implement this
+        if kernel == "apply_z_pow":
+            u1gate = self.cp.zeros((2, 2),dtype=state.dtype)
+            u1gate[0, 0], u1gate[1, 1] = 1, gate
+            gate = u1gate
         if gate is None:
             gate = self.cp.zeros((2, 2),dtype=state.dtype)
             if kernel == "apply_x":

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -411,8 +411,12 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         ntarget = 1
         target = nqubits - target - 1
         target = self.np.asarray([target], dtype = self.np.int32)
-        ncontrols = len(qubits) - 1 if qubits is not None else 0
-        controls = self.np.asarray([i for i in qubits.get() if i != target], dtype = self.np.int32)
+        if qubits is not None:
+            ncontrols = len(qubits) - 1
+            controls = self.np.asarray([i for i in qubits.get() if i != target], dtype = self.np.int32)
+        else:
+            ncontrols = 0
+            controls = self.np.empty()
         adjoint = 0
 
         state = self.cast(state)

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -478,8 +478,13 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         target1 = nqubits - target1 - 1
         target2 = nqubits - target2 - 1
         target = self.np.asarray([target2, target1], dtype=self.np.int32)
-        ncontrols = len(qubits) - 2 if qubits is not None else 0
-        controls = self.np.asarray([i for i in qubits.get() if i not in [target1, target2]], dtype = self.np.int32)
+        if qubits is not None:
+            ncontrols = len(qubits) - 2
+            controls = self.np.asarray([i for i in qubits.get() if i not in [target1, target2]], dtype = self.np.int32)
+        else:
+            ncontrols = 0
+            controls = self.np.empty()
+
         adjoint = 0
 
         state = self.cast(state)
@@ -495,7 +500,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
             maskOrdering = 0
             basisBits = target
             permutation  = self.np.asarray([0, 2, 1, 3], dtype=self.np.int64)
-            diagonals  = self.np.asarray([1,1,1,1], dtype=state.dtype)
+            diagonals  = self.np.asarray([1, 1, 1, 1], dtype=state.dtype)
 
             workspaceSize = self.cusv.apply_generalized_permutation_matrix_buffer_size(
                 handle,
@@ -654,10 +659,9 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
                                           1
                                           )
 
-
         if normalize:
-                norm  = self.cp.sqrt(self.cp.sum(self.cp.square(self.cp.abs(state))))
-                state = state / norm
+            norm  = self.cp.sqrt(self.cp.sum(self.cp.square(self.cp.abs(state))))
+            state = state / norm
 
         self.cusv.destroy(handle)
         return state

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -494,6 +494,17 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         controls = self.np.asarray([i for i in qubits.get() if i not in [target1, target2]], dtype = self.np.int32)
         adjoint = 0
 
+        if kernel == "apply_swap":
+            gate = self.cp.zeros((4, 4),dtype=state.dtype)
+            gate[0, 0], gate[3, 3] = 1, 1
+            gate[1, 2], gate[2, 1] = 1, 1
+        elif kernel == "apply_fsim":
+            fsimgate = self.cp.zeros((4, 4),dtype=state.dtype)
+            fsimgate[0, 0], fsimgate[3,3] = 1, gate[4]
+            fsimgate[1,1], fsimgate[1,2] = gate[0], gate[1]
+            fsimgate[2,1], fsimgate[2,2] = gate[2], gate[3]
+            gate = fsimgate
+
         state = self.cast(state)
         gate = self.cast(gate)
 

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -422,7 +422,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
                  self.cuquantum.cudaDataType.CUDA_C_32F,
                  self.cusv.MatrixLayout.ROW,
                  adjoint,
-                 0,
+                 1,
                  ncontrols,
                  self.cuquantum.ComputeType.COMPUTE_32F
                  )

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -391,9 +391,9 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
 
     def __init__(self):
         super(CuQuantumBackend, self).__init__()
-        import cuquantum
+        import cuquantum # pylint: disable=import-error
         from cuquantum import custatevec as cusv # pylint: disable=import-error
-        self.cuquantum = cuquantum # pylint: disable=import-error
+        self.cuquantum = cuquantum 
         self.cusv = cusv
         self.name = "cuquantum"
 

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -417,7 +417,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         # implement x, y, z and z_pow kernel since cuquantum only has apply_matrix
         # TODO: find a better way to implement this
         if gate is None:
-            gate = self.cp.zeros((2, 2))
+            gate = self.cp.zeros((2, 2),dtype=state.dtype)
             if kernel == "apply_x":
                 gate[0, 1], gate[1, 0] = 1, 1
             elif kernel == "apply_y":

--- a/src/qibojit/tests/conftest.py
+++ b/src/qibojit/tests/conftest.py
@@ -9,6 +9,16 @@ if K.gpu_devices:  # pragma: no cover
     _BACKENDS.extend(("cupy", "cuquantum"))
 
 @pytest.fixture
+def dtype(precision):
+    original_precision = qibo.get_precision()
+    qibo.set_precision(precision)
+    if precision == "double":
+        yield "complex128"
+    else:
+        yield "complex64"
+    qibo.set_precision(original_precision)
+
+@pytest.fixture
 def backend(backend_name):
     original_backend = K.engine.name
     K.set_engine(backend_name)
@@ -20,4 +30,4 @@ def pytest_generate_tests(metafunc):
     if "backend_name" in metafunc.fixturenames:
         metafunc.parametrize("backend_name", _BACKENDS)
     if "dtype" in metafunc.fixturenames:
-        metafunc.parametrize("dtype", ["complex128", "complex64"])
+        metafunc.parametrize("precision", ["double", "single"])

--- a/src/qibojit/tests/conftest.py
+++ b/src/qibojit/tests/conftest.py
@@ -4,14 +4,9 @@ from qibo import K
 qibo.set_backend("qibojit")
 
 _BACKENDS = ["numba"]
-if K._cupy_engine is not None:  # pragma: no cover
+if K.gpu_devices:  # pragma: no cover
     # CI does not test for GPU
-    _BACKENDS.append("cupy")
-
-if K._cuquantum_engine is not None:  # pragma: no cover
-    # CI does not test for GPU
-    _BACKENDS.append("cuquantum")
-
+    _BACKENDS.extend(("cupy", "cuquantum"))
 
 @pytest.fixture
 def backend(backend_name):

--- a/src/qibojit/tests/conftest.py
+++ b/src/qibojit/tests/conftest.py
@@ -6,7 +6,12 @@ qibo.set_backend("qibojit")
 _BACKENDS = ["numba"]
 if K.gpu_devices:  # pragma: no cover
     # CI does not test for GPU
-    _BACKENDS.extend(("cupy", "cuquantum"))
+    _BACKENDS.append("cupy")
+    try:
+        import cuquantum
+        _BACKENDS.append("cuquantum")
+    except ModuleNotFoundError:
+        pass
 
 @pytest.fixture
 def dtype(precision):

--- a/src/qibojit/tests/conftest.py
+++ b/src/qibojit/tests/conftest.py
@@ -8,6 +8,10 @@ if K._cupy_engine is not None:  # pragma: no cover
     # CI does not test for GPU
     _BACKENDS.append("cupy")
 
+if K._cuquantum_engine is not None:  # pragma: no cover
+    # CI does not test for GPU
+    _BACKENDS.append("cuquantum")
+
 
 @pytest.fixture
 def backend(backend_name):

--- a/src/qibojit/tests/test_ops.py
+++ b/src/qibojit/tests/test_ops.py
@@ -170,7 +170,7 @@ def test_swap_pieces(nqubits, qlocal, qglobal, dtype):
 def test_measure_frequencies(backend, realtype, inttype, nthreads):
     probs = np.ones(16, dtype=realtype) / 16
     frequencies = np.zeros(16, dtype=inttype)
-    if K.engine.name == "cupy":  # pragma: no cover
+    if K.engine.name in ["cupy", "cuquantum"]:  # pragma: no cover
         # CI does not test for GPU
         with pytest.raises(NotImplementedError):
             frequencies = K.engine.measure_frequencies(frequencies, probs, nshots=1000,


### PR DESCRIPTION
In this PR, as already discussed, my aim is to add the [CuQuantum](https://github.com/NVIDIA/cuQuantum) library as a new qibojit backend in order to add it to the benchmarked libraries.
The new backend is an inheritance from the `CupyBackend` since they both use `cupy`.
I tried to run this very simple example
```python
from qibo.models import Circuit
from qibo import gates

c = Circuit(1)
c.add(gates.H(0))
ex = c()
print(ex)
``` 
and I obtained a `CUDA_ERROR_ILLEGAL_ADDRESS`, the same thing happens if I try to access the initial state after the circuit execution. I'm guessing that the problem may be related to the different way the state vector is treated in cuquantum.
For the implementation I am following this [example](https://github.com/NVIDIA/cuQuantum/blob/main/python/samples/gate_application.py) from cuquantum.
Any ideas on how to fix this behaviour, @stavros11 , @mlazzarin @scarrazza ?


EDIT:
Things left to be implemented in this PR.
-  [x] add environment variable for switching between `cupy` and `cuquantum`
-  [x] fix qibo tests
-  [x] check if multi gpus is available (answer NO)
-  [x] find better implementation of swap gate
-  [x] try to implement custom collapse_state based on CuQuantum primitives
-  [ ] add installation instructions in doc