### PR TITLE
Test `one_qubit_base` and `two_qubit_base` directly

### DIFF
--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -392,7 +392,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         super().__init__()
         import cuquantum # pylint: disable=import-error
         from cuquantum import custatevec as cusv # pylint: disable=import-error
-        self.cuquantum = cuquantum 
+        self.cuquantum = cuquantum
         self.cusv = cusv
         self.name = "cuquantum"
 
@@ -416,7 +416,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
             controls = self.np.asarray([i for i in qubits.get() if i != target], dtype = self.np.int32)
         else:
             ncontrols = 0
-            controls = self.np.empty()
+            controls = self.np.empty(0)
         adjoint = 0
 
         state = self.cast(state)
@@ -483,7 +483,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
             controls = self.np.asarray([i for i in qubits.get() if i not in [target1, target2]], dtype = self.np.int32)
         else:
             ncontrols = 0
-            controls = self.np.empty()
+            controls = self.np.empty(0)
 
         adjoint = 0
 

--- a/src/qibojit/custom_operators/backends.py
+++ b/src/qibojit/custom_operators/backends.py
@@ -582,10 +582,10 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         ntarget = len(targets)
         if qubits is None:
             qubits = self.cast(sorted(nqubits - q - 1 for q in targets), dtype = self.cp.int32)
-        target = [ nqubits - q - 1 for q in targets]
+        target = [nqubits - q - 1 for q in targets]
         target = self.np.asarray(target[::-1], dtype = self.np.int32)
         controls = self.np.asarray([i for i in qubits.get() if i not in target], dtype = self.np.int32)
-        ncontrols = len(controls) if qubits is not None else 0
+        ncontrols = len(controls)
         adjoint = 0
         gate = self.cast(gate)
         assert state.dtype == gate.dtype

--- a/src/qibojit/tests/test_gates.py
+++ b/src/qibojit/tests/test_gates.py
@@ -42,6 +42,23 @@ def test_apply_gate(backend, nqubits, target, controls, dtype):
     K.assert_allclose(state, target_state, atol=ATOL.get(dtype))
 
 
+@pytest.mark.parametrize(("nqubits", "target"), [(4, 1), (6, 5)])
+@pytest.mark.parametrize("use_qubits", [False, True])
+def test_one_qubit_base(backend, nqubits, target, use_qubits, dtype):
+    state = random_state(nqubits, dtype=dtype)
+    matrix = random_complex((2, 2), dtype=dtype)
+
+    qibo.set_backend("numpy")
+    gate = gates.Unitary(matrix, target)
+    target_state = gate(K.copy(state))
+    qibo.set_backend("qibojit")
+
+    qubits = qubits_tensor(nqubits, [target]) if use_qubits else None
+    state = K.engine.one_qubit_base(state, nqubits, target, "apply_gate", matrix, qubits)
+    state = K.to_numpy(state)
+    K.assert_allclose(state, target_state, atol=ATOL.get(dtype))
+
+
 @pytest.mark.parametrize(("nqubits", "target", "controls"),
                          [(3, 0, []), (4, 3, []), (5, 2, []), (3, 1, []),
                           (3, 0, [1]), (4, 3, [0, 1]), (5, 2, [1, 3, 4])])
@@ -95,6 +112,22 @@ def test_apply_two_qubit_gate(backend, nqubits, targets, controls, dtype):
 
     qubits = qubits_tensor(nqubits, targets, controls)
     state = K.apply_two_qubit_gate(state, matrix, nqubits, targets, qubits)
+    K.assert_allclose(state, target_state, atol=ATOL.get(dtype))
+
+
+@pytest.mark.parametrize(("nqubits", "targets"), [(5, [3, 4]), (4, [2, 0])])
+@pytest.mark.parametrize("use_qubits", [False, True])
+def test_apply_two_qubit_gate(backend, nqubits, targets, use_qubits, dtype):
+    state = random_state(nqubits, dtype=dtype)
+    matrix = random_complex((4, 4), dtype=dtype)
+
+    qibo.set_backend("numpy")
+    gate = gates.Unitary(matrix, *targets)
+    target_state = gate(K.copy(state))
+    qibo.set_backend("qibojit")
+
+    qubits = qubits_tensor(nqubits, targets) if use_qubits else None
+    state = K.engine.two_qubit_base(state, nqubits, targets[0], targets[1], "apply_two_qubit_gate", matrix, qubits)
     K.assert_allclose(state, target_state, atol=ATOL.get(dtype))
 
 

--- a/src/qibojit/tests/test_gates.py
+++ b/src/qibojit/tests/test_gates.py
@@ -117,7 +117,7 @@ def test_apply_two_qubit_gate(backend, nqubits, targets, controls, dtype):
 
 @pytest.mark.parametrize(("nqubits", "targets"), [(5, [3, 4]), (4, [2, 0])])
 @pytest.mark.parametrize("use_qubits", [False, True])
-def test_apply_two_qubit_gate(backend, nqubits, targets, use_qubits, dtype):
+def test_apply_two_qubit_base(backend, nqubits, targets, use_qubits, dtype):
     state = random_state(nqubits, dtype=dtype)
     matrix = random_complex((4, 4), dtype=dtype)
 


### PR DESCRIPTION
Following some issues mentioned in #57 regarding `qubits=None`, this adds some tests that check the `one_qubit_base` and `two_qubit_base` directly with `qubits == None` and `qubits != None` to make sure we have full coverage on GPU. I also fixed some small mistakes in the newly testsd code.