### PR TITLE
cupy/cuquantum platform switcher

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -78,7 +78,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
 
     def test_regressions(self, name): # pragma: no cover
         # Used for qibo tests only
-        if self.platform.name == "cupy" or self.platform.name == "cuquantum":
+        if self.platform.name in ("cupy", "cuquantum"):
             return self.platform.test_regressions.get(name)
         return NumpyBackend.test_regressions(self, name)
 
@@ -141,7 +141,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
     def to_numpy(self, x):
         if isinstance(x, self.np.ndarray):
             return x
-        elif self.platform.name in ["cupy", "cuquantum"]  and isinstance(x, self.platform.cp.ndarray):  # pragma: no cover
+        elif self.platform.name in ("cupy", "cuquantum")  and isinstance(x, self.platform.cp.ndarray):  # pragma: no cover
             return x.get()
         return self.np.array(x)
 
@@ -151,7 +151,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return self.platform.cast(x, dtype=dtype)
 
     def check_shape(self, shape):
-        if self.platform.name in ["cupy", "cuquantum"]  and isinstance(shape, self.Tensor): # pragma: no cover
+        if self.platform.name in ("cupy", "cuquantum")  and isinstance(shape, self.Tensor): # pragma: no cover
             shape = shape.get()
         return shape
 
@@ -168,7 +168,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return super().ones(self.check_shape(shape), dtype=dtype)
 
     def expm(self, x):
-        if self.platform.name in ["cupy", "cuquantum"]: # pragma: no cover
+        if self.platform.name in ("cupy", "cuquantum"): # pragma: no cover
             # Fallback to numpy because cupy does not have expm
             if isinstance(x, self.native_types):
                 x = x.get()
@@ -189,14 +189,14 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return super().eigvalsh(x)
 
     def unique(self, x, return_counts=False):
-        if self.platform.name in ["cupy", "cuquantum"]:  # pragma: no cover
+        if self.platform.name in ("cupy", "cuquantum"):  # pragma: no cover
             if isinstance(x, self.native_types):
                 x = x.get()
             # Uses numpy backend always
         return super().unique(x, return_counts)
 
     def gather(self, x, indices=None, condition=None, axis=0):
-        if self.platform.name in ["cupy", "cuquantum"]:  # pragma: no cover
+        if self.platform.name in ("cupy", "cuquantum"):  # pragma: no cover
             # Fallback to numpy because cupy does not support tuple indexing
             if isinstance(x, self.native_types):
                 x = x.get()
@@ -339,7 +339,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         return self.reshape(state, original_shape)
 
     def assert_allclose(self, value, target, rtol=1e-7, atol=0.0):
-        if self.platform.name in ["cupy", "cuquantum"]: # pragma: no cover
+        if self.platform.name in ("cupy", "cuquantum"): # pragma: no cover
             if isinstance(value, self.backend.ndarray):
                 value = value.get()
             if isinstance(target, self.backend.ndarray):

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -37,8 +37,12 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         self.available_platforms = ["numba"]
         try:  # pragma: no cover
             from cupy import cuda # pylint: disable=E0401
-            ngpu = cuda.runtime.getDeviceCount()
-            self.available_platforms.append("cupy")
+            from cupy_backends.cuda.api.runtime import CUDARuntimeError
+            try:
+                ngpu = cuda.runtime.getDeviceCount()
+                self.available_platforms.append("cupy")
+            except CUDARuntimeError:
+                ngpu = 0
         except ModuleNotFoundError:
             ngpu = 0
         if ngpu > 0:

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -45,8 +45,8 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
                 ngpu = 0
         except ModuleNotFoundError:
             ngpu = 0
-        if ngpu > 0:
-            try:  # pragma: no cover
+        if ngpu > 0:  # pragma: no cover
+            try:
                 import cuquantum
                 self.available_platforms.append("cuquantum")
             except ModuleNotFoundError:

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -52,8 +52,8 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
             except ModuleNotFoundError:
                 pass
         # Construct ``NumbaPlatform``
-        from qibojit.custom_operators.backends import NumbaBackend
-        self._constructed_platforms = {"numba": NumbaBackend()}
+        from qibojit.custom_operators.platforms import NumbaPlatform
+        self._constructed_platforms = {"numba": NumbaPlatform()}
 
         import os
         if "OMP_NUM_THREADS" in os.environ: # pragma: no cover
@@ -97,15 +97,15 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
             import cupy as xp # pylint: disable=E0401
             self.tensor_types = (self.np.ndarray, xp.ndarray)
             if self._constructed_platforms.get("cupy") is None:
-                from qibojit.custom_operators.backends import CupyBackend
-                self._constructed_platforms["cupy"] = CupyBackend()
+                from qibojit.custom_operators.platforms import CupyPlatform
+                self._constructed_platforms["cupy"] = CupyPlatform()
             self.default_device = self.gpu_devices[0]
         elif name == "cuquantum":
             import cupy as xp # pylint: disable=E0401
             self.tensor_types = (self.np.ndarray, xp.ndarray)
             if self._constructed_platforms.get("cuquantum") is None:
-                from qibojit.custom_operators.backends import CuQuantumBackend
-                self._constructed_platforms["cuquantum"] = CuQuantumBackend()
+                from qibojit.custom_operators.platforms import CuQuantumPlatform
+                self._constructed_platforms["cuquantum"] = CuQuantumPlatform()
             self.default_device = self.gpu_devices[0]
 
         self.platform = self._constructed_platforms.get(name)

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 
-class AbstractBackend(ABC):
+class AbstractPlatform(ABC):
 
     def __init__(self): # pragma: no cover
         self.name = "abstract"
@@ -42,7 +42,7 @@ class AbstractBackend(ABC):
         raise NotImplementedError
 
 
-class NumbaBackend(AbstractBackend):
+class NumbaPlatform(AbstractPlatform):
 
     def __init__(self):
         import numpy as np
@@ -138,7 +138,7 @@ class NumbaBackend(AbstractBackend):
         return self.ops.measure_frequencies(frequencies, probs, nshots, nqubits, seed, nthreads)
 
 
-class CupyBackend(AbstractBackend): # pragma: no cover
+class CupyPlatform(AbstractPlatform): # pragma: no cover
     # CI does not test for GPU
 
     DEFAULT_BLOCK_SIZE = 1024
@@ -385,7 +385,7 @@ class CupyBackend(AbstractBackend): # pragma: no cover
                                   "implemented for GPU.")
 
 
-class CuQuantumBackend(CupyBackend): # pragma: no cover
+class CuQuantumPlatform(CupyPlatform): # pragma: no cover
     # CI does not test for GPU
 
     def __init__(self):

--- a/src/qibojit/tests/conftest.py
+++ b/src/qibojit/tests/conftest.py
@@ -3,7 +3,7 @@ import qibo
 from qibo import K
 qibo.set_backend("qibojit")
 
-_BACKENDS = ["numba"]
+_BACKENDS = ["numba"] # TODO: rename this to ``_PLATFORMS``
 if K.gpu_devices:  # pragma: no cover
     # CI does not test for GPU
     _BACKENDS.append("cupy")
@@ -25,10 +25,10 @@ def dtype(precision):
 
 @pytest.fixture
 def backend(backend_name):
-    original_backend = K.engine.name
-    K.set_engine(backend_name)
+    original_backend = K.platform.name
+    K.set_platform(backend_name)
     yield
-    K.set_engine(original_backend)
+    K.set_platform(original_backend)
 
 
 def pytest_generate_tests(metafunc):

--- a/src/qibojit/tests/conftest.py
+++ b/src/qibojit/tests/conftest.py
@@ -3,15 +3,6 @@ import qibo
 from qibo import K
 qibo.set_backend("qibojit")
 
-_BACKENDS = ["numba"] # TODO: rename this to ``_PLATFORMS``
-if K.gpu_devices:  # pragma: no cover
-    # CI does not test for GPU
-    _BACKENDS.append("cupy")
-    try:
-        import cuquantum
-        _BACKENDS.append("cuquantum")
-    except ModuleNotFoundError:
-        pass
 
 @pytest.fixture
 def dtype(precision):
@@ -23,16 +14,17 @@ def dtype(precision):
         yield "complex64"
     qibo.set_precision(original_precision)
 
+
 @pytest.fixture
-def backend(backend_name):
-    original_backend = K.platform.name
-    K.set_platform(backend_name)
+def backend(platform_name):
+    original_platform = K.platform.name
+    K.set_platform(platform_name)
     yield
-    K.set_platform(original_backend)
+    K.set_platform(original_platform)
 
 
 def pytest_generate_tests(metafunc):
-    if "backend_name" in metafunc.fixturenames:
-        metafunc.parametrize("backend_name", _BACKENDS)
+    if "platform_name" in metafunc.fixturenames:
+        metafunc.parametrize("platform_name", K.available_platforms)
     if "dtype" in metafunc.fixturenames:
         metafunc.parametrize("precision", ["double", "single"])

--- a/src/qibojit/tests/conftest.py
+++ b/src/qibojit/tests/conftest.py
@@ -16,7 +16,7 @@ def dtype(precision):
 
 
 @pytest.fixture
-def backend(platform_name):
+def platform(platform_name):
     original_platform = K.platform.name
     K.set_platform(platform_name)
     yield

--- a/src/qibojit/tests/test_backends.py
+++ b/src/qibojit/tests/test_backends.py
@@ -8,8 +8,7 @@ def test_platform_setter_and_getter(backend_name):
     K.set_platform(backend_name)
     assert K.platform.name == backend_name
     assert K.get_platform() == backend_name
-    with pytest.raises(ValueError):
-        K.set_platform("test")
+    K.set_platform("test")
     K.set_platform(original_backend)
 
 

--- a/src/qibojit/tests/test_backends.py
+++ b/src/qibojit/tests/test_backends.py
@@ -3,13 +3,14 @@ import numpy as np
 from qibo import K
 
 
-def test_engine_setter(backend_name):
-    original_backend = K.engine.name
-    K.set_engine(backend_name)
-    assert K.engine.name == backend_name
+def test_platform_setter_and_getter(backend_name):
+    original_backend = K.platform.name
+    K.set_platform(backend_name)
+    assert K.platform.name == backend_name
+    assert K.get_platform() == backend_name
     with pytest.raises(ValueError):
-        K.set_engine("test")
-    K.set_engine(original_backend)
+        K.set_platform("test")
+    K.set_platform(original_backend)
 
 
 def test_device_setter():
@@ -37,7 +38,7 @@ def test_cast(backend, array_type):
 def test_to_numpy(backend):
     x = [0, 1, 2]
     target = K.to_numpy(K.cast(x))
-    if K.engine.name == "numba":
+    if K.platform.name == "numba":
         final = K.to_numpy(x)
     else: # pragma: no cover
         final = K.to_numpy(np.array(x))

--- a/src/qibojit/tests/test_gates.py
+++ b/src/qibojit/tests/test_gates.py
@@ -27,7 +27,7 @@ def random_state(nqubits, dtype="complex128"):
                           (3, 0, [1, 2]), (4, 3, [0, 1, 2]),
                           (5, 3, [1]), (5, 2, [1, 4]), (6, 3, [0, 2, 5]),
                           (6, 3, [0, 2, 4, 5])])
-def test_apply_gate(backend, nqubits, target, controls, dtype):
+def test_apply_gate(platform, nqubits, target, controls, dtype):
     state = random_state(nqubits, dtype=dtype)
     matrix = random_complex((2, 2), dtype=dtype)
 
@@ -44,7 +44,7 @@ def test_apply_gate(backend, nqubits, target, controls, dtype):
 
 @pytest.mark.parametrize(("nqubits", "target"), [(4, 1), (6, 5)])
 @pytest.mark.parametrize("use_qubits", [False, True])
-def test_one_qubit_base(backend, nqubits, target, use_qubits, dtype):
+def test_one_qubit_base(platform, nqubits, target, use_qubits, dtype):
     state = random_state(nqubits, dtype=dtype)
     matrix = random_complex((2, 2), dtype=dtype)
 
@@ -63,7 +63,7 @@ def test_one_qubit_base(backend, nqubits, target, use_qubits, dtype):
                          [(3, 0, []), (4, 3, []), (5, 2, []), (3, 1, []),
                           (3, 0, [1]), (4, 3, [0, 1]), (5, 2, [1, 3, 4])])
 @pytest.mark.parametrize("pauli", ["x", "y", "z"])
-def test_apply_pauli_gate(backend, nqubits, target, pauli, controls, dtype):
+def test_apply_pauli_gate(platform, nqubits, target, pauli, controls, dtype):
     state = random_state(nqubits, dtype=dtype)
 
     qibo.set_backend("numpy")
@@ -81,7 +81,7 @@ def test_apply_pauli_gate(backend, nqubits, target, pauli, controls, dtype):
 @pytest.mark.parametrize(("nqubits", "target", "controls"),
                          [(3, 0, []), (3, 2, [1]),
                           (3, 2, [0, 1]), (6, 1, [0, 2, 4])])
-def test_apply_zpow_gate(backend, nqubits, target, controls, dtype):
+def test_apply_zpow_gate(platform, nqubits, target, controls, dtype):
     state = random_state(nqubits, dtype=dtype)
     theta = 0.1234
 
@@ -101,7 +101,7 @@ def test_apply_zpow_gate(backend, nqubits, target, controls, dtype):
                           (8, [6, 3], []), (3, [0, 1], [2]), (4, [1, 3], [0]),
                           (5, [2, 3], [1, 4]), (5, [3, 1], [0, 2]),
                           (6, [2, 5], [0, 1, 3, 4])])
-def test_apply_two_qubit_gate(backend, nqubits, targets, controls, dtype):
+def test_apply_two_qubit_gate(platform, nqubits, targets, controls, dtype):
     state = random_state(nqubits, dtype=dtype)
     matrix = random_complex((4, 4), dtype=dtype)
 
@@ -117,7 +117,7 @@ def test_apply_two_qubit_gate(backend, nqubits, targets, controls, dtype):
 
 @pytest.mark.parametrize(("nqubits", "targets"), [(5, [3, 4]), (4, [2, 0])])
 @pytest.mark.parametrize("use_qubits", [False, True])
-def test_apply_two_qubit_base(backend, nqubits, targets, use_qubits, dtype):
+def test_apply_two_qubit_base(platform, nqubits, targets, use_qubits, dtype):
     state = random_state(nqubits, dtype=dtype)
     matrix = random_complex((4, 4), dtype=dtype)
 
@@ -135,7 +135,7 @@ def test_apply_two_qubit_base(backend, nqubits, targets, use_qubits, dtype):
                          [(2, [0, 1], []), (3, [0, 2], []), (4, [1, 3], []),
                           (3, [1, 2], [0]), (4, [0, 2], [1]), (4, [2, 3], [0]),
                           (5, [3, 4], [1, 2]), (6, [1, 4], [0, 2, 5])])
-def test_apply_swap(backend, nqubits, targets, controls, dtype):
+def test_apply_swap(platform, nqubits, targets, controls, dtype):
     state = random_state(nqubits, dtype=dtype)
 
     qibo.set_backend("numpy")
@@ -153,7 +153,7 @@ def test_apply_swap(backend, nqubits, targets, controls, dtype):
                           (4, [0, 1], [2]), (5, [0, 1], [2]), (5, [3, 4], [2]),
                           (4, [0, 3], [1]), (4, [3, 2], [0]), (5, [1, 4], [2]),
                           (6, [1, 3], [0, 4]), (6, [5, 0], [1, 2, 3])])
-def test_apply_fsim(backend, nqubits, targets, controls, dtype):
+def test_apply_fsim(platform, nqubits, targets, controls, dtype):
     state = random_state(nqubits, dtype=dtype)
     matrix = random_complex((2, 2), dtype=dtype)
     phi = 0.4321
@@ -203,7 +203,7 @@ def test_apply_multiqubit_gate(nqubits, targets, controls, dtype):
 
 @pytest.mark.parametrize("gatename", ["H", "X", "Z"])
 @pytest.mark.parametrize("density_matrix", [False, True])
-def test_gates_on_circuit(backend, gatename, density_matrix):
+def test_gates_on_circuit(platform, gatename, density_matrix):
     from qibo.models import Circuit
     if density_matrix:
         state = random_complex((2, 2))
@@ -224,7 +224,7 @@ def test_gates_on_circuit(backend, gatename, density_matrix):
 
 
 @pytest.mark.parametrize("gatename", ["H", "X", "Z"])
-def test_density_matrix_half_calls(backend, gatename):
+def test_density_matrix_half_calls(platform, gatename):
     state = random_complex((8, 8))
     state = state + np.conj(state.T)
     qibo.set_backend("numpy")

--- a/src/qibojit/tests/test_gates.py
+++ b/src/qibojit/tests/test_gates.py
@@ -54,7 +54,7 @@ def test_one_qubit_base(backend, nqubits, target, use_qubits, dtype):
     qibo.set_backend("qibojit")
 
     qubits = qubits_tensor(nqubits, [target]) if use_qubits else None
-    state = K.engine.one_qubit_base(state, nqubits, target, "apply_gate", matrix, qubits)
+    state = K.platform.one_qubit_base(state, nqubits, target, "apply_gate", matrix, qubits)
     state = K.to_numpy(state)
     K.assert_allclose(state, target_state, atol=ATOL.get(dtype))
 
@@ -127,7 +127,7 @@ def test_apply_two_qubit_base(backend, nqubits, targets, use_qubits, dtype):
     qibo.set_backend("qibojit")
 
     qubits = qubits_tensor(nqubits, targets) if use_qubits else None
-    state = K.engine.two_qubit_base(state, nqubits, targets[0], targets[1], "apply_two_qubit_gate", matrix, qubits)
+    state = K.platform.two_qubit_base(state, nqubits, targets[0], targets[1], "apply_two_qubit_gate", matrix, qubits)
     K.assert_allclose(state, target_state, atol=ATOL.get(dtype))
 
 

--- a/src/qibojit/tests/test_ops.py
+++ b/src/qibojit/tests/test_ops.py
@@ -24,7 +24,7 @@ def test_initial_state(backend, precision, is_matrix):
 
 @pytest.mark.parametrize("is_matrix", [False, True])
 def test_backends_initial_state(backend, dtype, is_matrix):
-    final_state =  K.engine.initial_state(4, dtype, is_matrix)
+    final_state =  K.platform.initial_state(4, dtype, is_matrix)
     if is_matrix:
         target_state = np.array([1] + [0]*255, dtype=dtype)
         target_state = np.reshape(target_state, (16, 16))
@@ -170,16 +170,16 @@ def test_swap_pieces(nqubits, qlocal, qglobal, dtype):
 def test_measure_frequencies(backend, realtype, inttype, nthreads):
     probs = np.ones(16, dtype=realtype) / 16
     frequencies = np.zeros(16, dtype=inttype)
-    if K.engine.name in ["cupy", "cuquantum"]:  # pragma: no cover
+    if K.platform.name in ["cupy", "cuquantum"]:  # pragma: no cover
         # CI does not test for GPU
         with pytest.raises(NotImplementedError):
-            frequencies = K.engine.measure_frequencies(frequencies, probs, nshots=1000,
-                                                       nqubits=4, seed=1234,
-                                                       nthreads=nthreads)
+            frequencies = K.platform.measure_frequencies(frequencies, probs, nshots=1000,
+                                                         nqubits=4, seed=1234,
+                                                         nthreads=nthreads)
     else:
-        frequencies = K.engine.measure_frequencies(frequencies, probs, nshots=1000,
-                                                   nqubits=4, seed=1234,
-                                                   nthreads=nthreads)
+        frequencies = K.platform.measure_frequencies(frequencies, probs, nshots=1000,
+                                                     nqubits=4, seed=1234,
+                                                     nthreads=nthreads)
         assert np.sum(frequencies) == 1000
         if nthreads is not None:
             target_frequencies = np.array([72, 65, 63, 54, 57, 55, 67, 50, 53, 67, 69,

--- a/src/qibojit/tests/test_ops.py
+++ b/src/qibojit/tests/test_ops.py
@@ -8,7 +8,7 @@ from qibojit.tests.test_gates import qubits_tensor, random_complex, random_state
 
 @pytest.mark.parametrize("precision", ["double", "single"])
 @pytest.mark.parametrize("is_matrix", [False, True])
-def test_initial_state(backend, precision, is_matrix):
+def test_initial_state(platform, precision, is_matrix):
     original_precision = K.precision
     dtype = "complex128" if precision == "double" else "complex64"
     K.set_precision(precision)
@@ -23,7 +23,7 @@ def test_initial_state(backend, precision, is_matrix):
 
 
 @pytest.mark.parametrize("is_matrix", [False, True])
-def test_backends_initial_state(backend, dtype, is_matrix):
+def test_backends_initial_state(platform, dtype, is_matrix):
     final_state =  K.platform.initial_state(4, dtype, is_matrix)
     if is_matrix:
         target_state = np.array([1] + [0]*255, dtype=dtype)
@@ -38,7 +38,7 @@ def test_backends_initial_state(backend, dtype, is_matrix):
                           (4, [1, 3], [1, 0]), (5, [1, 2, 4], [0, 1, 1]),
                           (15, [4, 7], [0, 0]), (16, [8, 12, 15], [1, 0, 1])])
 @pytest.mark.parametrize("normalize", [False, True])
-def test_collapse_state(backend, nqubits, targets, results, normalize, dtype):
+def test_collapse_state(platform, nqubits, targets, results, normalize, dtype):
     atol = 1e-7 if dtype == "complex64" else 1e-14
     state = random_state(nqubits, dtype)
     slicer = nqubits * [slice(None)]
@@ -62,7 +62,7 @@ def test_collapse_state(backend, nqubits, targets, results, normalize, dtype):
 
 @pytest.mark.parametrize("gatename", ["H", "X", "Z"])
 @pytest.mark.parametrize("density_matrix", [False, True])
-def test_collapse_call(backend, gatename, density_matrix):
+def test_collapse_call(platform, gatename, density_matrix):
     from qibo import gates
     if density_matrix:
         state = random_complex((8, 8))
@@ -167,7 +167,7 @@ def test_swap_pieces(nqubits, qlocal, qglobal, dtype):
 @pytest.mark.parametrize("realtype", ["float32", "float64"])
 @pytest.mark.parametrize("inttype", ["int32", "int64"])
 @pytest.mark.parametrize("nthreads", [None, 4])
-def test_measure_frequencies(backend, realtype, inttype, nthreads):
+def test_measure_frequencies(platform, realtype, inttype, nthreads):
     probs = np.ones(16, dtype=realtype) / 16
     frequencies = np.zeros(16, dtype=inttype)
     if K.platform.name in ["cupy", "cuquantum"]:  # pragma: no cover
@@ -193,7 +193,7 @@ NONZERO.extend(itertools.combinations(range(8), r=3))
 NONZERO.extend(itertools.combinations(range(8), r=4))
 NSHOTS = (len(NONZERO) // 2 + 1) * [1000, 200000]
 @pytest.mark.parametrize("nonzero,nshots", zip(NONZERO, NSHOTS))
-def test_measure_frequencies_sparse_probabilities(backend, nonzero, nshots):
+def test_measure_frequencies_sparse_probabilities(platform, nonzero, nshots):
     probs = np.zeros(8, dtype=np.float64)
     for i in nonzero:
         probs[i] = 1

--- a/src/qibojit/tests/test_platforms.py
+++ b/src/qibojit/tests/test_platforms.py
@@ -3,13 +3,13 @@ import numpy as np
 from qibo import K
 
 
-def test_platform_setter_and_getter(backend_name):
-    original_backend = K.platform.name
-    K.set_platform(backend_name)
-    assert K.platform.name == backend_name
-    assert K.get_platform() == backend_name
+def test_platform_setter_and_getter(platform_name):
+    original_platform = K.platform.name
+    K.set_platform(platform_name)
+    assert K.platform.name == platform_name
+    assert K.get_platform() == platform_name
     K.set_platform("test")
-    K.set_platform(original_backend)
+    K.set_platform(original_platform)
 
 
 def test_device_setter():

--- a/src/qibojit/tests/test_platforms.py
+++ b/src/qibojit/tests/test_platforms.py
@@ -28,13 +28,13 @@ def test_thread_setter():
 
 
 @pytest.mark.parametrize("array_type", [None, "float32", "float64"])
-def test_cast(backend, array_type):
+def test_cast(platform, array_type):
     target = np.random.random(10)
     final = K.to_numpy(K.cast(target, dtype=array_type))
     K.assert_allclose(final, target)
 
 
-def test_to_numpy(backend):
+def test_to_numpy(platform):
     x = [0, 1, 2]
     target = K.to_numpy(K.cast(x))
     if K.platform.name == "numba":
@@ -44,7 +44,7 @@ def test_to_numpy(backend):
     K.assert_allclose(final, target)
 
 
-def test_basic_matrices(backend):
+def test_basic_matrices(platform):
     K.assert_allclose(K.eye(4), np.eye(4))
     K.assert_allclose(K.zeros((3, 3)), np.zeros((3, 3)))
     K.assert_allclose(K.ones((5, 5)), np.ones((5, 5)))
@@ -53,7 +53,7 @@ def test_basic_matrices(backend):
     K.assert_allclose(K.expm(m), expm(m))
 
 
-def test_backend_eigh(backend):
+def test_backend_eigh(platform):
     m = np.random.random((16, 16))
     eigvals2, eigvecs2 = np.linalg.eigh(m)
     eigvals1, eigvecs1 = K.eigh(K.cast(m))
@@ -61,14 +61,14 @@ def test_backend_eigh(backend):
     K.assert_allclose(K.abs(eigvecs1), np.abs(eigvecs2))
 
 
-def test_backend_eigvalsh(backend):
+def test_backend_eigvalsh(platform):
     m = np.random.random((16, 16))
     target = np.linalg.eigvalsh(m)
     result = K.eigvalsh(K.cast(m))
     K.assert_allclose(target, result)
 
 
-def test_unique_and_gather(backend):
+def test_unique_and_gather(platform):
     samples = np.random.randint(0, 2, size=(100,))
     K.assert_allclose(K.unique(samples), np.unique(samples))
     indices = [0, 2, 6, 40]
@@ -76,7 +76,7 @@ def test_unique_and_gather(backend):
     K.assert_allclose(final, samples[indices])
 
 
-def test_with_device(backend):
+def test_with_device(platform):
     with K.device("/CPU:0"):
         pass
     with K.device("/GPU:0"):
@@ -88,10 +88,10 @@ def test_with_device(backend):
     K.assert_allclose(final, target)
 
 
-def test_cpu_ops(backend):
+def test_cpu_ops(platform):
     with K.on_cpu():
         pass
 
 
-def test_cpu_fallback(backend):
+def test_cpu_fallback(platform):
     state = K.cpu_fallback(K.initial_state, 4)


### PR DESCRIPTION
Implements the cupy/cuquantum switcher using the upgraded `qibo.set_backend()` introduced in qiboteam/qibo#533. The engine was renamed to platform to be consistent with the hardware backends and `NumbaBackend`, `CupyBackend`, etc was renamed to `NumbaPlatform`, `CupyPlatform`, etc so that we have a clear distinction between backends (numpy, tensorflow, qibotf, qibojit) and platforms (numba, cupy, cuquantum).

The `GPU_ENGINE` environment variable was also renamed to `QIBOJIT_PLATFORM`.