### PR TITLE
Force C order casting for GPU

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -9,9 +9,10 @@ class CupyCpuDevice:  # pragma: no cover
 
     def __init__(self, K):
         self.K = K
+        self.original_platform = None
 
     def __enter__(self, *args):
-        name = self.K.platform.name
+        name = self.K.get_platform()
         if name != "numba":
             self.original_platform = name
         self.K.set_platform("numba")

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -65,7 +65,7 @@ class NumbaPlatform(AbstractPlatform):
                 return x.astype(dtype, copy=False, order=order)
         else:
             try:
-                x = self.np.array(x, dtype=dtype)
+                x = self.np.array(x, dtype=dtype, order=order)
             # only for CuPy arrays, as implicit conversion raises TypeError
             # and you need to cast manually using x.get()
             except TypeError: # pragma: no cover

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -10,7 +10,7 @@ class AbstractPlatform(ABC):
         self.test_regressions = {}
 
     @abstractmethod
-    def cast(self, x, dtype=None): # pragma: no cover
+    def cast(self, x, dtype=None, order=None): # pragma: no cover
         raise NotImplementedError
 
     @abstractmethod
@@ -57,19 +57,19 @@ class NumbaPlatform(AbstractPlatform):
             5: self.gates.apply_five_qubit_gate_kernel
             }
 
-    def cast(self, x, dtype=None):
+    def cast(self, x, dtype=None, order='K'):
         if isinstance(x, self.np.ndarray):
             if dtype is None:
                 return x
             else:
-                return x.astype(dtype, copy=False)
+                return x.astype(dtype, copy=False, order=order)
         else:
             try:
                 x = self.np.array(x, dtype=dtype)
             # only for CuPy arrays, as implicit conversion raises TypeError
             # and you need to cast manually using x.get()
             except TypeError: # pragma: no cover
-                x = self.np.array(x.get(), dtype=dtype, copy=False)
+                x = self.np.array(x.get(), dtype=dtype, copy=False, order=order)
             return x
 
     def one_qubit_base(self, state, nqubits, target, kernel, gate, qubits=None):
@@ -234,13 +234,13 @@ class CupyPlatform(AbstractPlatform): # pragma: no cover
             block_size = nstates
         return nblocks, block_size
 
-    def cast(self, x, dtype=None):
+    def cast(self, x, dtype=None, order='C'):
         if isinstance(x, self.cp.ndarray):
             if dtype is None:
                 return x
             else:
-                return x.astype(dtype, copy=False)
-        return self.cp.asarray(x, dtype=dtype)
+                return x.astype(dtype, copy=False, order=order)
+        return self.cp.asarray(x, dtype=dtype, order=order)
 
     def get_kernel_type(self, state):
         if state.dtype == self.cp.complex128:
@@ -640,7 +640,6 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
         return state
 
     def collapse_state(self, state, qubits, result, nqubits, normalize=True):
-
         handle = self.cusv.create()
         state = self.cast(state)
         results = bin(result).replace("0b", "")

--- a/src/qibojit/tests/test_gates.py
+++ b/src/qibojit/tests/test_gates.py
@@ -22,6 +22,13 @@ def random_state(nqubits, dtype="complex128"):
     return x / np.sqrt(np.sum(np.abs(x) ** 2))
 
 
+def random_unitary(nqubits, dtype="complex128"):
+    from scipy.linalg import expm
+    shape = 2 * (2 ** nqubits,)
+    m = random_complex(shape, dtype=dtype)
+    return expm(1j * (m + m.T.conj()))
+
+
 @pytest.mark.parametrize(("nqubits", "target", "controls"),
                          [(5, 4, []), (4, 2, []), (3, 0, []), (8, 5, []),
                           (3, 0, [1, 2]), (4, 3, [0, 1, 2]),
@@ -29,7 +36,7 @@ def random_state(nqubits, dtype="complex128"):
                           (6, 3, [0, 2, 4, 5])])
 def test_apply_gate(platform, nqubits, target, controls, dtype):
     state = random_state(nqubits, dtype=dtype)
-    matrix = random_complex((2, 2), dtype=dtype)
+    matrix = random_unitary(1, dtype=dtype)
 
     qibo.set_backend("numpy")
     gate = gates.Unitary(matrix, target).controlled_by(*controls)
@@ -103,7 +110,7 @@ def test_apply_zpow_gate(platform, nqubits, target, controls, dtype):
                           (6, [2, 5], [0, 1, 3, 4])])
 def test_apply_two_qubit_gate(platform, nqubits, targets, controls, dtype):
     state = random_state(nqubits, dtype=dtype)
-    matrix = random_complex((4, 4), dtype=dtype)
+    matrix = random_unitary(2, dtype=dtype)
 
     qibo.set_backend("numpy")
     gate = gates.Unitary(matrix, *targets).controlled_by(*controls)


### PR DESCRIPTION
Fixes #62 by using `order='C'` in the platform cast methods. Added relevant tests that use `expm` too.

I suggest to keep this PR open until we confirm that tests in qiboteam/qibo#539 are passing for all platforms.