### PR TITLE
adding info message concerning compilation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,6 @@ this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-
-class CustomInstall(install):
-    def run(self):
-        install.run(self)
-        os.environ["CUDA_VISIBLE_DEVICES"] = ""
-        os.environ["HIP_VISIBLE_DEVICES"] = ""
-        from qibo import K
-
-
 setup(
     name=PACKAGE,
     version=get_version(),
@@ -45,9 +36,6 @@ setup(
     package_dir={"": "src"},
     package_data={"": ["*.cc"]},
     zip_safe=False,
-    cmdclass = {
-        "install": CustomInstall
-    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Physics",

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -45,6 +45,12 @@ class AbstractPlatform(ABC):
 class NumbaPlatform(AbstractPlatform):
 
     def __init__(self):
+        # check if cache exists
+        from pathlib import Path
+        if list((Path(__file__).parent / "__pycache__").glob("*.nbi")) == []:
+            from qibo.config import log
+            log.info("Importing qibojit for the first time, compiling kernels, please wait.")
+
         import numpy as np
         from qibojit.custom_operators import gates, ops
         self.name = "numba"

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -47,9 +47,10 @@ class NumbaPlatform(AbstractPlatform):
     def __init__(self):
         # check if cache exists
         from pathlib import Path
-        if list((Path(__file__).parent / "__pycache__").glob("*.nbi")) == []: # pragma: no cover
+        if not list((Path(__file__).parent / "__pycache__").glob("*.nbi")): # pragma: no cover
             from qibo.config import log
-            log.info("Importing qibojit for the first time, compiling kernels, please wait.")
+            log.info("Compiling kernels because qibojit is imported for the first time," \
+                     "please wait. Compilation happens only once after installing qibojit.")
 
         import numpy as np
         from qibojit.custom_operators import gates, ops

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -47,7 +47,7 @@ class NumbaPlatform(AbstractPlatform):
     def __init__(self):
         # check if cache exists
         from pathlib import Path
-        if list((Path(__file__).parent / "__pycache__").glob("*.nbi")) == []:
+        if list((Path(__file__).parent / "__pycache__").glob("*.nbi")) == []: # pragma: no cover
             from qibo.config import log
             log.info("Importing qibojit for the first time, compiling kernels, please wait.")
 


### PR DESCRIPTION
Following #63, I think the solution proposed in this PR is the cleanest, i.e. we avoid precompilation at installation time however during compilation (first import) the code prints a message explaining what is going on.

@stavros11 let me know if you agree.