### PR TITLE
Move `supports_multigpu` flag to platforms

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -62,6 +62,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         if "NUMBA_NUM_THREADS" in os.environ: # pragma: no cover
             self.set_threads(int(os.environ.get("NUMBA_NUM_THREADS")))
 
+        self.platform = None
         self.cpu_devices = ["/CPU:0"]
         self.gpu_devices = [f"/GPU:{i}" for i in range(ngpu)]
         if self.gpu_devices: # pragma: no cover
@@ -71,11 +72,6 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
             self.set_platform(os.environ.get("QIBOJIT_PLATFORM", "numba"))
             self.set_threads(self.nthreads)
         self.cupy_cpu_device = CupyCpuDevice(self)
-
-        # enable multi-GPU if no macos
-        import sys
-        if sys.platform != "darwin":
-            self.supports_multigpu = True
 
     def test_regressions(self, name): # pragma: no cover
         # Used for qibo tests only
@@ -118,6 +114,10 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         self.Tensor = xp.ndarray
         self.random = xp.random
         self.newaxis = xp.newaxis
+        # enable multi-GPU if no macos
+        import sys
+        if sys.platform != "darwin":
+            self.supports_multigpu = self.platform.supports_multigpu
         if "GPU" in self.default_device: # pragma: no cover
             with self.device(self.default_device):
                 self.matrices.allocate_matrices()

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -407,6 +407,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
         self.cuquantum = cuquantum
         self.cusv = cusv
         self.name = "cuquantum"
+        self.supports_multigpu = False
 
     def get_cuda_type(self, dtype='complex64'):
         if dtype == 'complex128':

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -8,6 +8,7 @@ class AbstractPlatform(ABC):
         self.gates = None
         self.ops = None
         self.test_regressions = {}
+        self.supports_multigpu = False
 
     @abstractmethod
     def cast(self, x, dtype=None, order=None): # pragma: no cover
@@ -54,6 +55,7 @@ class NumbaPlatform(AbstractPlatform):
 
         import numpy as np
         from qibojit.custom_operators import gates, ops
+        super().__init__()
         self.name = "numba"
         self.gates = gates
         self.ops = ops
@@ -162,9 +164,11 @@ class CupyPlatform(AbstractPlatform): # pragma: no cover
         except cp.cuda.runtime.CUDARuntimeError:
             raise ImportError("Could not detect cupy compatible devices.")
 
+        super().__init__()
         self.name = "cupy"
         self.np = np
         self.cp = cp
+        self.supports_multigpu = True
         self.is_hip = cupy_backends.cuda.api.runtime.is_hip
         self.KERNELS = ("apply_gate", "apply_x", "apply_y", "apply_z", "apply_z_pow",
                         "apply_two_qubit_gate", "apply_fsim", "apply_swap")


### PR DESCRIPTION
Qibo backends have a `supports_multigpu` flag that specifies whether the underlying backend supports multigpu or no. Here I delegate this flag to platforms for the qibojit backend and I disable multigpu support for numba and cuquantum, leaving it only for cupy (following the discussion in qiboteam/qibo#539). 

The `supports_multigpu` flag is used by qiboteam/qibo#539 to decide for which backends we will run the multigpu tests as well as a few other parts of qibo code in order to raise errors if a distributed execution is attempted with a backend that does not support it. The only disadvantage of the implementation here is that multigpu using the numba backend is disabled, even though in principle works (despite everything is running on CPU). I believe it is better to have a clearer distinction though and only enable multigpu for actual GPU backends.