### PR TITLE
Support sparse matrices in cast methods

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -341,14 +341,6 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         state = self._constructed_platforms.get("numba").transpose_state(pieces, state, nqubits, order)
         return self.reshape(state, original_shape)
 
-    def assert_allclose(self, value, target, rtol=1e-7, atol=0.0):
-        if self.platform.name in ("cupy", "cuquantum"): # pragma: no cover
-            if isinstance(value, self.backend.ndarray):
-                value = value.get()
-            if isinstance(target, self.backend.ndarray):
-                target = target.get()
-        self.np.testing.assert_allclose(value, target, rtol=rtol, atol=atol)
-
     def apply_gate(self, state, gate, nqubits, targets, qubits=None):
         return self.platform.one_qubit_base(state, nqubits, *targets, "apply_gate", gate, qubits)
 

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -118,6 +118,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         self.Tensor = xp.ndarray
         self.random = xp.random
         self.newaxis = xp.newaxis
+        self.sparse = self.platform.sparse
         if "GPU" in self.default_device: # pragma: no cover
             with self.device(self.default_device):
                 self.matrices.allocate_matrices()

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -150,6 +150,9 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
             dtype = self.dtypes(dtype)
         return self.platform.cast(x, dtype=dtype)
 
+    def issparse(self, x):
+        return self.platform.issparse(x)
+
     def check_shape(self, shape):
         if self.platform.name in ("cupy", "cuquantum")  and isinstance(shape, self.Tensor): # pragma: no cover
             shape = shape.get()

--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -143,9 +143,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
     def to_numpy(self, x):
         if isinstance(x, self.np.ndarray):
             return x
-        elif self.platform.name in ("cupy", "cuquantum")  and isinstance(x, self.platform.cp.ndarray):  # pragma: no cover
-            return x.get()
-        return self.np.array(x)
+        return self.platform.to_numpy(x)
 
     def cast(self, x, dtype='DTYPECPX'):
         if isinstance(dtype, str):

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -15,6 +15,14 @@ class AbstractPlatform(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def to_numpy(self, x): # pragma: no cover
+        raise NotImplementedError
+
+    @abstractmethod
+    def issparse(self, x): # pragma: no cover
+        raise NotImplementedError
+
+    @abstractmethod
     def one_qubit_base(self, state, nqubits, target, kernel, gate, qubits=None): # pragma: no cover
         raise NotImplementedError
 
@@ -87,6 +95,9 @@ class NumbaPlatform(AbstractPlatform):
         if self.sparse.issparse(x):
             return x.toarray()
         return self.np.array(x, copy=False)
+
+    def issparse(self, x):
+        return self.sparse.issparse(x)
 
     def one_qubit_base(self, state, nqubits, target, kernel, gate, qubits=None):
         ncontrols = len(qubits) - 1 if qubits is not None else 0
@@ -276,6 +287,9 @@ class CupyPlatform(AbstractPlatform): # pragma: no cover
         elif self.npsparse.issparse(x):
             return x.toarray()
         return self.np.array(x, copy=False)
+
+    def issparse(self, x):
+        return self.sparse.issparse(x) or self.npsparse.issparse(x)
 
     def get_kernel_type(self, state):
         if state.dtype == self.cp.complex128:

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -73,7 +73,7 @@ class NumbaPlatform(AbstractPlatform):
         if isinstance(x, self.np.ndarray):
             return x.astype(dtype, copy=False, order=order)
         elif self.sparse.issparse(x):
-            return x.__class__(x, dtype=dtype)
+            return x.astype(dtype, copy=False)
         else:
             try:
                 x = self.np.array(x, dtype=dtype, order=order)
@@ -259,7 +259,10 @@ class CupyPlatform(AbstractPlatform): # pragma: no cover
         if isinstance(x, self.cp.ndarray):
             return x.astype(dtype, copy=False, order=order)
         elif self.sparse.issparse(x):
-            return x.__class__(x, dtype=dtype)
+            if dtype != x.dtype:
+                return x.astype(dtype)
+            else:
+                return x
         elif self.npsparse.issparse(x):
             cls = getattr(self.sparse, x.__class__.__name__)
             return cls(x, dtype=dtype)

--- a/src/qibojit/tests/test_platforms.py
+++ b/src/qibojit/tests/test_platforms.py
@@ -101,20 +101,17 @@ def test_backend_eigvalsh(platform, sparse_type):
 
 
 @pytest.mark.parametrize("sparse_type", ["coo", "csr", "csc", "dia"])
-@pytest.mark.parametrize("k", [6, 10])
+@pytest.mark.parametrize("k", [6, 8])
 def test_backend_eigh_sparse(platform, sparse_type, k):
-    if K.get_platform() != "numba":  # pragma: no cover
-        pytest.skip("Skipping sparse eigenvalue test for GPU platforms "
-                    "because it is unstable.")
     from scipy.sparse.linalg import eigsh
     from scipy import sparse
     from qibo import hamiltonians
     ham = hamiltonians.TFIM(6, h=1.0)
     m = getattr(sparse, f"{sparse_type}_matrix")(K.to_numpy(ham.matrix))
     eigvals1, eigvecs1 = K.eigh(K.cast(m), k)
-    eigvals2, eigvecs2 = eigsh(m, k)
-    eigvals1 = np.abs(K.to_numpy(eigvals1))
-    eigvals2 = np.abs(K.to_numpy(eigvals2))
+    eigvals2, eigvecs2 = eigsh(m, k, which='SA')
+    eigvals1 = K.to_numpy(eigvals1)
+    eigvals2 = K.to_numpy(eigvals2)
     K.assert_allclose(sorted(eigvals1), sorted(eigvals2))
 
 

--- a/src/qibojit/tests/test_platforms.py
+++ b/src/qibojit/tests/test_platforms.py
@@ -35,9 +35,10 @@ def test_cast(platform, array_type):
 
 
 @pytest.mark.parametrize("array_type", [None, "float32", "float64"])
-def test_sparse_cast(platform, array_type):
+@pytest.mark.parametrize("format", ["coo", "csr", "csc", "dia"])
+def test_sparse_cast(platform, array_type, format):
     from scipy import sparse
-    sptarget = sparse.rand(512, 512, dtype=array_type)
+    sptarget = sparse.rand(512, 512, dtype=array_type, format=format)
     final = K.to_numpy(K.cast(sptarget))
     target = sptarget.toarray()
     K.assert_allclose(final, target)

--- a/src/qibojit/tests/test_platforms.py
+++ b/src/qibojit/tests/test_platforms.py
@@ -34,6 +34,19 @@ def test_cast(platform, array_type):
     K.assert_allclose(final, target)
 
 
+@pytest.mark.parametrize("array_type", [None, "float32", "float64"])
+def test_sparse_cast(platform, array_type):
+    from scipy import sparse
+    sptarget = sparse.rand(512, 512, dtype=array_type)
+    final = K.to_numpy(K.cast(sptarget))
+    target = sptarget.toarray()
+    K.assert_allclose(final, target)
+    if K.platform.name != "numba":  # pragma: no cover
+        sptarget = getattr(K.sparse, sptarget.__class__.__name__)(sptarget)
+        final = K.to_numpy(K.cast(sptarget))
+        K.assert_allclose(final, target)
+
+
 def test_to_numpy(platform):
     x = [0, 1, 2]
     target = K.to_numpy(K.cast(x))

--- a/src/qibojit/tests/test_platforms.py
+++ b/src/qibojit/tests/test_platforms.py
@@ -39,11 +39,13 @@ def test_cast(platform, array_type):
 def test_sparse_cast(platform, array_type, format):
     from scipy import sparse
     sptarget = sparse.rand(512, 512, dtype=array_type, format=format)
+    assert K.issparse(sptarget)
     final = K.to_numpy(K.cast(sptarget))
     target = sptarget.toarray()
     K.assert_allclose(final, target)
     if K.platform.name != "numba":  # pragma: no cover
         sptarget = getattr(K.sparse, sptarget.__class__.__name__)(sptarget)
+        assert K.issparse(sptarget)
         final = K.to_numpy(K.cast(sptarget))
         K.assert_allclose(final, target)
 


### PR DESCRIPTION
Required to enable qibo Hamiltonian creation using sparse matrices. Sparse matrices are supported for both numba (via `scipy.sparse`) and cupy/cuquantum (via `cupy.sparse`) platforms.