### PR TITLE
Update qubits type for cuquantum

### DIFF
--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -426,7 +426,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
         target = self.np.asarray([target], dtype = self.np.int32)
         if qubits is not None:
             ncontrols = len(qubits) - 1
-            controls = self.np.asarray([i for i in qubits.get() if i != target], dtype = self.np.int32)
+            controls = self.np.array([i for i in qubits if i != target], dtype = self.np.int32)
         else:
             ncontrols = 0
             controls = self.np.empty(0)
@@ -493,7 +493,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
         target = self.np.asarray([target2, target1], dtype=self.np.int32)
         if qubits is not None:
             ncontrols = len(qubits) - 2
-            controls = self.np.asarray([i for i in qubits.get() if i not in [target1, target2]], dtype = self.np.int32)
+            controls = self.np.asarray([i for i in qubits if i not in [target1, target2]], dtype = self.np.int32)
         else:
             ncontrols = 0
             controls = self.np.empty(0)
@@ -597,7 +597,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
             qubits = self.cast(sorted(nqubits - q - 1 for q in targets), dtype = self.cp.int32)
         target = [nqubits - q - 1 for q in targets]
         target = self.np.asarray(target[::-1], dtype = self.np.int32)
-        controls = self.np.asarray([i for i in qubits.get() if i not in target], dtype = self.np.int32)
+        controls = self.np.asarray([i for i in qubits if i not in target], dtype = self.np.int32)
         ncontrols = len(controls)
         adjoint = 0
         gate = self.cast(gate)
@@ -657,7 +657,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
         results = bin(result).replace("0b", "")
         results = list(map(int,  '0'* (len(qubits) - len(results)) + results))[::-1]
         ntarget = 1
-        qubits = self.np.asarray(qubits.get(), dtype = self.np.int32)
+        qubits = self.np.asarray(qubits, dtype = self.np.int32)
         data_type, compute_type = self.get_cuda_type(state.dtype)
 
         for i  in range(len(results)):

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -426,7 +426,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
         target = self.np.asarray([target], dtype = self.np.int32)
         if qubits is not None:
             ncontrols = len(qubits) - 1
-            controls = self.np.array([i for i in qubits if i != target], dtype = self.np.int32)
+            controls = self.np.asarray([i for i in qubits if i != target], dtype = self.np.int32)
         else:
             ncontrols = 0
             controls = self.np.empty(0)

--- a/src/qibojit/tests/test_gates.py
+++ b/src/qibojit/tests/test_gates.py
@@ -9,7 +9,7 @@ ATOL = {"complex64": 1e-5, "complex128": 1e-10}
 def qubits_tensor(nqubits, targets, controls=[]):
     qubits = [nqubits - q - 1 for q in targets]
     qubits.extend(nqubits - q - 1 for q in controls)
-    return K.cast(sorted(qubits), dtype="int32")
+    return K.np.array(sorted(qubits), dtype="int32")
 
 
 def random_complex(shape, dtype="complex128"):

--- a/src/qibojit/tests/test_ops.py
+++ b/src/qibojit/tests/test_ops.py
@@ -53,7 +53,7 @@ def test_collapse_state(platform, nqubits, targets, results, normalize, dtype):
         norm = (np.abs(target_state) ** 2).sum()
         target_state = target_state / np.sqrt(norm)
 
-    qubits = K.cast(sorted(nqubits - np.array(targets, dtype=np.int32) - 1),dtype=np.int32)
+    qubits = K.np.array(sorted(nqubits - t - 1 for t in targets), dtype=np.int32)
     b2d = 2 ** np.arange(len(results) - 1, -1, -1)
     result = int(np.array(results).dot(b2d))
     state = K.collapse_state(state, qubits, result, nqubits, normalize)


### PR DESCRIPTION
Cuquantum tests are failing for #69 because `.get()` is now used on a numpy array. This should fix the issue. Using this version, both qibo and qibojit tests are passing for me on both my laptop and DGX, with and without cuquantum. Would be good to double check.