### PR TITLE
Improving CuQuantum Implementation

### DIFF
--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -412,6 +412,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
 
     def __del__(self):
         self.cusv.destroy(self.handle)
+        super().__del__()
 
     def get_cuda_type(self, dtype='complex64'):
         if dtype == 'complex128':

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -412,7 +412,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
 
     def __del__(self):
         self.cusv.destroy(self.handle)
-        super().__del__()
+        super().__del__() # pylint: disable=E1101
 
     def get_cuda_type(self, dtype='complex64'):
         if dtype == 'complex128':


### PR DESCRIPTION
In this PR I try to improve our cuquantum backend in order to reduce the dry run and the simulation time which are very different compared to our cupy backend in the case of some circuit like the QFT.

As suggested by the NVIDIA guys the implementation now uses only one handle which is initiated in the constructor and its destroyed in the destructor of the CuQuantum platform.

I'll upload some benchmarks shortly.