### PR TITLE
Change `.flatten()` to `.ravel()` to avoid copies

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -270,7 +270,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         qubits = gate.cache.qubits_tensor + gate.nqubits
         shape = state.shape
         gate_op = self.get_gate_op(gate)
-        state = gate_op(state.flatten(), 2 * gate.nqubits, gate.target_qubits, qubits)
+        state = gate_op(state.ravel(), 2 * gate.nqubits, gate.target_qubits, qubits)
         state = gate_op(state, 2 * gate.nqubits, gate.cache.target_qubits_dm, gate.cache.qubits_tensor)
         return self.reshape(state, shape)
 
@@ -278,7 +278,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         qubits = gate.cache.qubits_tensor + gate.nqubits
         shape = state.shape
         gate_op = self.get_gate_op(gate)
-        state = gate_op(state.flatten(), gate.custom_op_matrix, 2 * gate.nqubits, gate.target_qubits, qubits)
+        state = gate_op(state.ravel(), gate.custom_op_matrix, 2 * gate.nqubits, gate.target_qubits, qubits)
         adjmatrix = self.conj(gate.custom_op_matrix)
         state = gate_op(state, adjmatrix, 2 * gate.nqubits, gate.cache.target_qubits_dm, gate.cache.qubits_tensor)
         return self.reshape(state, shape)
@@ -287,14 +287,14 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         qubits = gate.cache.qubits_tensor + gate.nqubits
         shape = state.shape
         gate_op = self.get_gate_op(gate)
-        state = gate_op(state.flatten(), 2 * gate.nqubits, gate.target_qubits, qubits)
+        state = gate_op(state.ravel(), 2 * gate.nqubits, gate.target_qubits, qubits)
         return self.reshape(state, shape)
 
     def density_matrix_half_matrix_call(self, gate, state):
         qubits = gate.cache.qubits_tensor + gate.nqubits
         shape = state.shape
         gate_op = self.get_gate_op(gate)
-        state = gate_op(state.flatten(), gate.custom_op_matrix, 2 * gate.nqubits, gate.target_qubits, qubits)
+        state = gate_op(state.ravel(), gate.custom_op_matrix, 2 * gate.nqubits, gate.target_qubits, qubits)
         return self.reshape(state, shape)
 
     def _result_tensor(self, result):
@@ -309,7 +309,7 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
         result = self._result_tensor(result)
         qubits = gate.cache.qubits_tensor + gate.nqubits
         shape = state.shape
-        state = self.collapse_state(state.flatten(), qubits, result, 2 * gate.nqubits, False)
+        state = self.collapse_state(state.ravel(), qubits, result, 2 * gate.nqubits, False)
         state = self.collapse_state(state, gate.cache.qubits_tensor, result, 2 * gate.nqubits, False)
         state = self.reshape(state, shape)
         return state / self.trace(state)

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -334,7 +334,7 @@ class CupyPlatform(AbstractPlatform): # pragma: no cover
         if kernel in ("apply_x", "apply_y", "apply_z"):
             args = (state, tk, m)
         else:
-            args = (state, tk, m, self.cast(gate, dtype=state.dtype).flatten())
+            args = (state, tk, m, self.cast(gate, dtype=state.dtype).ravel())
 
         ktype = self.get_kernel_type(state)
         if ncontrols:
@@ -366,7 +366,7 @@ class CupyPlatform(AbstractPlatform): # pragma: no cover
         if kernel == "apply_swap":
             args = (state, tk1, tk2, m1, m2, uk1, uk2)
         else:
-            args = (state, tk1, tk2, m1, m2, uk1, uk2, self.cast(gate).flatten())
+            args = (state, tk1, tk2, m1, m2, uk1, uk2, self.cast(gate).ravel())
             assert state.dtype == args[-1].dtype
 
         ktype = self.get_kernel_type(state)
@@ -384,7 +384,7 @@ class CupyPlatform(AbstractPlatform): # pragma: no cover
     def multi_qubit_base(self, state, nqubits, targets, gate, qubits=None):
         assert gate is not None
         state = self.cast(state)
-        gate = self.cast(gate.flatten())
+        gate = self.cast(gate.ravel())
         assert state.dtype == gate.dtype
 
         ntargets = len(targets)


### PR DESCRIPTION
While working on a qibo callback I realized that qibojit creates copies, instead of using in-place updates, when simulating density matrices. This is true on CPU and GPU.

Here is a script to reproduce this issue:
```py
import numpy as np
from qibo import gates, K
from qibo.models import Circuit

state = np.zeros((4, 4), dtype=np.complex128)
state[0, 0] = 1

state = K.cast(state)
c = Circuit(2, density_matrix=True)
c.add(gates.H(0))
c.add(gates.H(1))
final_state = c(initial_state=state)

print(state)
print(final_state.state())
```
will print
```
[Qibo 0.1.8.dev0|INFO|2022-03-10 14:20:02]: Using qibojit (numba) backend on /CPU:0
[[1.+0.j 0.+0.j 0.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 0.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 0.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 0.+0.j 0.+0.j]]
[[0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j]
 [0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j]
 [0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j]
 [0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j]]
```
which means that the matrix was copied somewhere, as the initial state was not modified. The equivalent for state vectors
```py
import numpy as np
from qibo import gates, K
from qibo.models import Circuit

state = np.zeros(4, dtype=np.complex128)
state[0] = 1

state = K.cast(state)
c = Circuit(2)
c.add(gates.H(0))
c.add(gates.H(1))
final_state = c(initial_state=state)

print(state)
print(final_state.state())
```
will print
```
[Qibo 0.1.8.dev0|INFO|2022-03-10 14:21:06]: Using qibojit (numba) backend on /CPU:0
[0.5+0.j 0.5+0.j 0.5+0.j 0.5+0.j]
[0.5+0.j 0.5+0.j 0.5+0.j 0.5+0.j]
```
so it modifies the initial state too.

Apparently using `state.flatten()` creates a copy of the state. Here I am replacing it with `.ravel()` which returns a flattened version without copying. I tested with cupy and `.flatten()` indeed duplicates the used GPU memory, while `.ravel()` does not. The above example is also fixed with this branch. I have not checked how the overal performance is affected for density matrix simulation, but it would be good to do so before merging.