### PR TITLE
Fix `expm` for sparse matrices on GPU

### DIFF
--- a/src/qibojit/custom_operators/__init__.py
+++ b/src/qibojit/custom_operators/__init__.py
@@ -173,9 +173,9 @@ class JITCustomBackend(NumpyBackend, AbstractCustomOperators):
     def expm(self, x):
         if self.platform.name in ("cupy", "cuquantum"): # pragma: no cover
             # Fallback to numpy because cupy does not have expm
-            if isinstance(x, self.native_types):
+            if isinstance(x, self.native_types) or self.issparse(x):
                 x = x.get()
-            return self.backend.asarray(super().expm(x))
+            return self.cast(super().expm(x), dtype=x.dtype)
         return super().expm(x)
 
     def eigh(self, x, k=6):

--- a/src/qibojit/tests/test_platforms.py
+++ b/src/qibojit/tests/test_platforms.py
@@ -86,6 +86,20 @@ def test_backend_eigh(platform, sparse_type):
 
 
 @pytest.mark.parametrize("sparse_type", [None, "coo", "csr", "csc", "dia"])
+def test_backend_expm(platform, sparse_type):
+    if sparse_type is None:
+        from scipy.linalg import expm
+        m = np.random.random((16, 16))
+    else:
+        from scipy.sparse import rand
+        from scipy.sparse.linalg import expm
+        m = rand(16, 16, format=sparse_type)
+    target = expm(m)
+    result = K.expm(K.cast(m))
+    K.assert_allclose(target, result, atol=1e-10)
+
+
+@pytest.mark.parametrize("sparse_type", [None, "coo", "csr", "csc", "dia"])
 def test_backend_eigvalsh(platform, sparse_type):
     if sparse_type is None:
         m = np.random.random((16, 16))

--- a/src/qibojit/tests/test_platforms.py
+++ b/src/qibojit/tests/test_platforms.py
@@ -69,6 +69,16 @@ def test_basic_matrices(platform):
     K.assert_allclose(K.expm(m), expm(m))
 
 
+@pytest.mark.parametrize("sparse_type", ["coo", "csr", "csc", "dia"])
+def test_backend_expm_sparse(platform, sparse_type):
+    from scipy.linalg import expm
+    from scipy.sparse import rand
+    m = rand(16, 16, format=sparse_type)
+    target = expm(m.toarray())
+    result = K.to_numpy(K.expm(K.cast(m)))
+    K.assert_allclose(target, result, atol=1e-10)
+
+
 @pytest.mark.parametrize("sparse_type", [None, "coo", "csr", "csc", "dia"])
 def test_backend_eigh(platform, sparse_type):
     if sparse_type is None:
@@ -83,20 +93,6 @@ def test_backend_eigh(platform, sparse_type):
         eigvals2, eigvecs2 = K.eigh(K.cast(m.toarray()))
     K.assert_allclose(eigvals1, eigvals2, atol=1e-10)
     K.assert_allclose(K.abs(eigvecs1), np.abs(eigvecs2), atol=1e-10)
-
-
-@pytest.mark.parametrize("sparse_type", [None, "coo", "csr", "csc", "dia"])
-def test_backend_expm(platform, sparse_type):
-    if sparse_type is None:
-        from scipy.linalg import expm
-        m = np.random.random((16, 16))
-    else:
-        from scipy.sparse import rand
-        from scipy.sparse.linalg import expm
-        m = rand(16, 16, format=sparse_type)
-    target = expm(m)
-    result = K.expm(K.cast(m))
-    K.assert_allclose(target, result, atol=1e-10)
 
 
 @pytest.mark.parametrize("sparse_type", [None, "coo", "csr", "csc", "dia"])


### PR DESCRIPTION
While fixing the tests of qiboteam/qibo#542 on GPU I was getting some failures associated with using `expm` on sparse matrices. This PR should fix this issue.

@andrea-pasquale when you have time, please try to run the qibojit and qibo tests using this branch (`fixexpm`) for qibojit and the `sparse` branch for qibo. All tests should now pass on CPU and GPU.