### PR TITLE
Update cuQuantum version

### DIFF
--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -540,8 +540,8 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
                                target.ctypes.data,
                                ntarget,
                                controls.ctypes.data,
-                               ncontrols,
                                0,
+                               ncontrols,
                                compute_type,
                                workspace_ptr,
                                workspaceSize
@@ -641,8 +641,8 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
                                target.ctypes.data,
                                ntarget,
                                controls.ctypes.data,
-                               ncontrols,
                                0,
+                               ncontrols,
                                compute_type,
                                workspace_ptr,
                                workspaceSize
@@ -701,8 +701,8 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
                                target.ctypes.data,
                                ntarget,
                                controls.ctypes.data,
-                               ncontrols,
                                0,
+                               ncontrols,
                                compute_type,
                                workspace_ptr,
                                workspaceSize

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -570,11 +570,6 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
         data_type, compute_type = self.get_cuda_type(state.dtype)
 
         if kernel == 'apply_swap' and ncontrols == 0:
-            nBasisBits = 2
-            maskLen = 0
-            maskBitString = 0
-            maskOrdering = 0
-            basisBits = target
             permutation  = self.np.asarray([0, 2, 1, 3], dtype=self.np.int64)
             diagonals  = self.np.asarray([1, 1, 1, 1], dtype=state.dtype)
 
@@ -585,9 +580,9 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
                 permutation.ctypes.data,
                 diagonals.ctypes.data,
                 data_type,
-                basisBits,
-                nBasisBits,
-                maskLen)
+                target,
+                ntarget,
+                ncontrols)
 
             if workspaceSize > 0:
                 workspace = self.cp.cuda.memory.alloc(workspaceSize)
@@ -599,7 +594,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
             self.cusv.apply_generalized_permutation_matrix(
                 self.handle, state.data.ptr, data_type, nqubits,
                 permutation.ctypes.data, diagonals.ctypes.data, data_type, adjoint,
-                basisBits, nBasisBits, maskBitString, maskOrdering, maskLen,
+                target, ntarget, 0, 0, ncontrols,
                 workspace_ptr, workspaceSize)
 
             return state

--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -510,7 +510,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
         else:
             raise ValueError
 
-        workspaceSize = self.cusv.apply_matrix_buffer_size(self.handle,
+        workspaceSize = self.cusv.apply_matrix_get_workspace_size(self.handle,
                                                            data_type,
                                                            nqubits,
                                                            gate_ptr,
@@ -578,7 +578,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
             permutation  = self.np.asarray([0, 2, 1, 3], dtype=self.np.int64)
             diagonals  = self.np.asarray([1, 1, 1, 1], dtype=state.dtype)
 
-            workspaceSize = self.cusv.apply_generalized_permutation_matrix_buffer_size(
+            workspaceSize = self.cusv.apply_generalized_permutation_matrix_get_workspace_size(
                 self.handle,
                 data_type,
                 nqubits,
@@ -611,7 +611,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
         else:
             raise ValueError
 
-        workspaceSize = self.cusv.apply_matrix_buffer_size(self.handle,
+        workspaceSize = self.cusv.apply_matrix_get_workspace_size(self.handle,
                                                            data_type,
                                                            nqubits,
                                                            gate_ptr,
@@ -671,7 +671,7 @@ class CuQuantumPlatform(CupyPlatform): # pragma: no cover
         else:
             raise ValueError
 
-        workspaceSize = self.cusv.apply_matrix_buffer_size(self.handle,
+        workspaceSize = self.cusv.apply_matrix_get_workspace_size(self.handle,
                                                            data_type,
                                                            nqubits,
                                                            gate_ptr,


### PR DESCRIPTION
Closes #76. This PR fixes a few bugs that we had with  [latest](https://docs.nvidia.com/cuda/cuquantum/python/release_notes.html#cuquantum-python-v22-03-0) version of cuquatum.
Now, both qibo and qibojit tests are passing on dom. @stavros11 when you have time please check if tests are passing also for you.

