### PR TITLE
Change `.ravel()` back to `.flatten()` for gates

### DIFF
--- a/src/qibojit/custom_operators/platforms.py
+++ b/src/qibojit/custom_operators/platforms.py
@@ -334,7 +334,7 @@ class CupyPlatform(AbstractPlatform): # pragma: no cover
         if kernel in ("apply_x", "apply_y", "apply_z"):
             args = (state, tk, m)
         else:
-            args = (state, tk, m, self.cast(gate, dtype=state.dtype).ravel())
+            args = (state, tk, m, self.cast(gate, dtype=state.dtype).flatten())
 
         ktype = self.get_kernel_type(state)
         if ncontrols:
@@ -366,7 +366,7 @@ class CupyPlatform(AbstractPlatform): # pragma: no cover
         if kernel == "apply_swap":
             args = (state, tk1, tk2, m1, m2, uk1, uk2)
         else:
-            args = (state, tk1, tk2, m1, m2, uk1, uk2, self.cast(gate).ravel())
+            args = (state, tk1, tk2, m1, m2, uk1, uk2, self.cast(gate).flatten())
             assert state.dtype == args[-1].dtype
 
         ktype = self.get_kernel_type(state)
@@ -384,7 +384,7 @@ class CupyPlatform(AbstractPlatform): # pragma: no cover
     def multi_qubit_base(self, state, nqubits, targets, gate, qubits=None):
         assert gate is not None
         state = self.cast(state)
-        gate = self.cast(gate.ravel())
+        gate = self.cast(gate.flatten())
         assert state.dtype == gate.dtype
 
         ntargets = len(targets)


### PR DESCRIPTION
The latest version of qibojit fails when running multigpu circuits on a machine with multiple physical GPUs. For example the following minimal example:
```Python
from qibo import models, gates

circuit = models.Circuit(3, accelerators={"/GPU:0": 1, "/GPU:1": 1})
circuit.add(gates.H(0))

final_state = c()
print(final_state)
```
fails with
```
cupy_backends.cuda.api.runtime.CUDARuntimeError: cudaErrorIllegalAddress: an illegal memory access was encountered
```

After checking earlier qibojit versions I realized that the error is associated with #74 and particularly because `.flatten()` was changed to `.ravel()` for some gate castings. This is fixed here and the above example works. Also, all tests are passing.

@scarrazza @andrea-pasquale, if you have access to a machine with multiple physical GPUs it would be good if you could check if the latest qibojit main gives you the above error and confirm that this PR fixes it. I found this while running the qibo tests on DGX. Note that the machine needs to have at least two GPUs, if there is only one (or the second GPU is hidden with CUDA_VISIBLE_DEVICES) then the error will not appear.