### PR TITLE
Fix cuquantum tests

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -22,7 +22,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pylint
         pip install pytest-cov
-        pip install git+https://github.com/qiboteam/qibo@abstractions
+        pip install git+https://github.com/qiboteam/qibo
         pip install .
     - name: Test with pylint
       run: |

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -431,7 +431,7 @@ class CuQuantumBackend(CupyBackend): # pragma: no cover
         self.cuquantum = cuquantum
         self.cusv = cusv
         self.platform = "cuquantum"
-        self.supports_multigpu = False
+        self.supports_multigpu = True
         self.handle = self.cusv.create()
         self.custom_matrices = CuQuantumMatrices(self.dtype)
 

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -328,13 +328,13 @@ class CupyBackend(NumbaBackend): # pragma: no cover
                                       "execution. Please create a new circuit with "
                                       "different device configuration and try again.")
 
-    def get_state_tensor(self, result):
+    def circuit_result_tensor(self, result):
         if isinstance(result.execution_result, list):
             # transform distributed state pieces to tensor
             ops = MultiGpuOps(self, NumbaBackend(), result.circuit)
             return ops.to_tensor(result.execution_result)
         else:
-            return super().get_state_tensor(result)
+            return super().circuit_result_tensor(result)
 
     #def calculate_symbolic(self, state, nqubits, decimals=5, cutoff=1e-10, max_terms=20): Inherited from ``NumpyBackend``
 


### PR DESCRIPTION
Fixes qibo/abstractions tests when using cuquantum. 

@andrea-pasquale when you have time, could you please try to run all qibo (on `abstractions` branch) and qibojit tests using numba, cupy and cuquantum and confirm that everything is working? After this small fix, all is okay from my side.

It would also be great if we could test AMD HIP given that we promise this feature because I do not have access to an AMD GPU and I cannot test this.