### PR TITLE
Add version attribute in backends

### DIFF
--- a/src/qibojit/backends/cpu.py
+++ b/src/qibojit/backends/cpu.py
@@ -29,7 +29,6 @@ class NumbaBackend(NumpyBackend):
 
         import psutil
         from numba import __version__ as numba_version
-        from qibo import __version__ as qibo_version
 
         from qibojit import __version__ as qibojit_version
         from qibojit.custom_operators import gates, ops

--- a/src/qibojit/backends/cpu.py
+++ b/src/qibojit/backends/cpu.py
@@ -36,10 +36,12 @@ class NumbaBackend(NumpyBackend):
 
         self.name = "qibojit"
         self.platform = "numba"
-        self.versions.update({
-            "qibojit": qibojit_version,
-            "numba": numba_version,
-        })
+        self.versions.update(
+            {
+                "qibojit": qibojit_version,
+                "numba": numba_version,
+            }
+        )
         self.numeric_types = (
             int,
             float,

--- a/src/qibojit/backends/cpu.py
+++ b/src/qibojit/backends/cpu.py
@@ -36,12 +36,10 @@ class NumbaBackend(NumpyBackend):
 
         self.name = "qibojit"
         self.platform = "numba"
-        self.versions = {
-            "qibo": qibo_version,
+        self.versions.update({
             "qibojit": qibojit_version,
-            "numpy": self.np.__version__,
             "numba": numba_version,
-        }
+        })
         self.numeric_types = (
             int,
             float,

--- a/src/qibojit/backends/cpu.py
+++ b/src/qibojit/backends/cpu.py
@@ -31,10 +31,16 @@ class NumbaBackend(NumpyBackend):
 
         from qibojit.custom_operators import gates, ops
         from qibojit import __version__
+        from qibo import __version__ as qibo_version
+        from numba import __version__ as numba_version
 
         self.name = "qibojit"
         self.platform = "numba"
-        self.version = __version__
+        self.versions = {
+            "qibo" : qibo_version,
+            "numpy": self.np.__version__,
+            "numba": numba_version
+        }
         self.numeric_types = (
             int,
             float,

--- a/src/qibojit/backends/cpu.py
+++ b/src/qibojit/backends/cpu.py
@@ -28,19 +28,19 @@ class NumbaBackend(NumpyBackend):
         import sys
 
         import psutil
-
-        from qibo import __version__ as qibo_version
         from numba import __version__ as numba_version
+        from qibo import __version__ as qibo_version
+
         from qibojit import __version__ as qibojit_version
         from qibojit.custom_operators import gates, ops
 
         self.name = "qibojit"
         self.platform = "numba"
         self.versions = {
-            "qibo" : qibo_version,
+            "qibo": qibo_version,
             "qibojit": qibojit_version,
             "numpy": self.np.__version__,
-            "numba": numba_version
+            "numba": numba_version,
         }
         self.numeric_types = (
             int,

--- a/src/qibojit/backends/cpu.py
+++ b/src/qibojit/backends/cpu.py
@@ -30,9 +30,11 @@ class NumbaBackend(NumpyBackend):
         import psutil
 
         from qibojit.custom_operators import gates, ops
+        from qibojit import __version__
 
         self.name = "qibojit"
         self.platform = "numba"
+        self.version = __version__
         self.numeric_types = (
             int,
             float,

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -19,16 +19,17 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
 
         import cupy as cp  # pylint: disable=import-error
         import cupy_backends  # pylint: disable=import-error
-        from qibojit import __version__ as qibojit_version
         from qibo import __version__ as qibo_version
+
+        from qibojit import __version__ as qibojit_version
 
         self.name = "qibojit"
         self.platform = "cupy"
         self.versions = {
-            "qibo" : qibo_version,
+            "qibo": qibo_version,
             "qibojit": qibojit_version,
             "numpy": self.np.__version__,
-            "cupy": self.cp.__version__
+            "cupy": self.cp.__version__,
         }
         self.supports_multigpu = True
         self.numeric_types = (
@@ -489,19 +490,19 @@ class CuQuantumBackend(CupyBackend):  # pragma: no cover
         super().__init__()
         import cuquantum  # pylint: disable=import-error
         from cuquantum import custatevec as cusv  # pylint: disable=import-error
+        from qibo import __version__ as qibo_version
 
         from qibojit import __version__
-        from qibo import __version__ as qibo_version
 
         self.cuquantum = cuquantum
         self.cusv = cusv
         self.platform = "cuquantum"
         self.versions = {
-            "qibo" : qibo_version,
+            "qibo": qibo_version,
             "qibojit": __version__,
             "numpy": np.__version__,
             "cupy": self.cp.__version__,
-            "cuquantum": self.cuquantum.__version__
+            "cuquantum": self.cuquantum.__version__,
         }
         self.supports_multigpu = True
         self.handle = self.cusv.create()

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -15,22 +15,16 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
 
     def __init__(self):
         NumpyBackend.__init__(self)
-        import os
 
         import cupy as cp  # pylint: disable=import-error
         import cupy_backends  # pylint: disable=import-error
-        from qibo import __version__ as qibo_version
-
-        from qibojit import __version__ as qibojit_version
 
         self.name = "qibojit"
         self.platform = "cupy"
-        self.versions = {
-            "qibo": qibo_version,
-            "qibojit": qibojit_version,
-            "numpy": self.np.__version__,
-            "cupy": cp.__version__,
-        }
+        self.versions[
+            "cupy" : cp.__version__,
+        ]
+
         self.supports_multigpu = True
         self.numeric_types = (
             int,
@@ -490,9 +484,6 @@ class CuQuantumBackend(CupyBackend):  # pragma: no cover
         super().__init__()
         import cuquantum  # pylint: disable=import-error
         from cuquantum import custatevec as cusv  # pylint: disable=import-error
-        from qibo import __version__ as qibo_version
-
-        from qibojit import __version__
 
         self.cuquantum = cuquantum
         self.cusv = cusv

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -29,7 +29,7 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
             "qibo": qibo_version,
             "qibojit": qibojit_version,
             "numpy": self.np.__version__,
-            "cupy": self.cp.__version__,
+            "cupy": cp.__version__,
         }
         self.supports_multigpu = True
         self.numeric_types = (
@@ -497,13 +497,7 @@ class CuQuantumBackend(CupyBackend):  # pragma: no cover
         self.cuquantum = cuquantum
         self.cusv = cusv
         self.platform = "cuquantum"
-        self.versions = {
-            "qibo": qibo_version,
-            "qibojit": __version__,
-            "numpy": np.__version__,
-            "cupy": self.cp.__version__,
-            "cuquantum": self.cuquantum.__version__,
-        }
+        self.versions["cuquantum"] = self.cuquantum.__version__
         self.supports_multigpu = True
         self.handle = self.cusv.create()
         self.custom_matrices = CuQuantumMatrices(self.dtype)

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -19,11 +19,16 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
 
         import cupy as cp  # pylint: disable=import-error
         import cupy_backends  # pylint: disable=import-error
-        from qibojit import __version__
+        from qibojit import __version__ as qibojit_version
+        from qibo import __version__ as qibo_version
 
         self.name = "qibojit"
         self.platform = "cupy"
-        self.version = __version__
+        self.versions = {
+            "qibo" : qibo_version,
+            "numpy": self.np.__version__,
+            "cupy": self.cp.__version__
+        }
         self.supports_multigpu = True
         self.numeric_types = (
             int,
@@ -488,7 +493,12 @@ class CuQuantumBackend(CupyBackend):  # pragma: no cover
         self.cuquantum = cuquantum
         self.cusv = cusv
         self.platform = "cuquantum"
-        self.version = __version__
+        self.versions = {
+            "qibo" : qibo_version,
+            "numpy": np.__version__,
+            "cupy": self.cp.__version__,
+            "cuquantum": self.cuquantum.__version__
+        }
         self.supports_multigpu = True
         self.handle = self.cusv.create()
         self.custom_matrices = CuQuantumMatrices(self.dtype)

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -19,9 +19,11 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
 
         import cupy as cp  # pylint: disable=import-error
         import cupy_backends  # pylint: disable=import-error
+        from qibojit import __version__
 
         self.name = "qibojit"
         self.platform = "cupy"
+        self.version = __version__
         self.supports_multigpu = True
         self.numeric_types = (
             int,
@@ -481,10 +483,12 @@ class CuQuantumBackend(CupyBackend):  # pragma: no cover
         super().__init__()
         import cuquantum  # pylint: disable=import-error
         from cuquantum import custatevec as cusv  # pylint: disable=import-error
+        from qibojit import __version__
 
         self.cuquantum = cuquantum
         self.cusv = cusv
         self.platform = "cuquantum"
+        self.version = __version__
         self.supports_multigpu = True
         self.handle = self.cusv.create()
         self.custom_matrices = CuQuantumMatrices(self.dtype)

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -21,9 +21,7 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
 
         self.name = "qibojit"
         self.platform = "cupy"
-        self.versions[
-            "cupy" : cp.__version__,
-        ]
+        self.versions["cupy"] = cp.__version__
 
         self.supports_multigpu = True
         self.numeric_types = (


### PR DESCRIPTION
Similarly to qiboteam/qibo#643, I am adding the backend version as an attribute inside the backend class.
For this case I decided to store directly for each backend the `qibojit` version. 
I was also thinking that we could store directly the `numba` version or the `cupy` version.
Let me know what you prefer.

