### PR TITLE
Fix qibo matrices import

### DIFF
--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -492,7 +492,8 @@ class CuQuantumBackend(CupyBackend):  # pragma: no cover
         self.custom_matrices = CuQuantumMatrices(self.dtype)
 
     def __del__(self):
-        self.cusv.destroy(self.handle)
+        if hasattr(self, "cusv"):
+            self.cusv.destroy(self.handle)
 
     def set_precision(self, precision):
         if precision != self.precision:

--- a/src/qibojit/backends/matrices.py
+++ b/src/qibojit/backends/matrices.py
@@ -2,7 +2,7 @@
 import sys
 
 import numpy as np
-from qibo.backends.matrices import Matrices
+from qibo.backends.npmatrices import NumpyMatrices
 
 if sys.version_info.minor >= 8:
     from functools import cached_property  # pylint: disable=E0611
@@ -18,7 +18,7 @@ else:
         return wrapper
 
 
-class CuQuantumMatrices(Matrices):
+class CuQuantumMatrices(NumpyMatrices):
     # These matrices are used by the custom operators and may
     # not correspond to the mathematical representation of each gate
 


### PR DESCRIPTION
qibo/backends/matrices.py is renamed to npmatrices.py and this updates qibojit imports accordingly. Only works with qiboteam/qibo#677.