### PR TITLE
Measurements with registers on gpu (cupy)

### DIFF
--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -340,7 +340,9 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
                     "Initial state type {} is not supported by "
                     "distributed circuits.".format(type(initial_state)),
                 )
-
+            for gate in circuit.queue:
+                if isinstance(gate, M):
+                    gate.result.backend = CupyBackend()
             special_gates = iter(circuit.queues.special_queue)
             for i, queues in enumerate(circuit.queues.queues):
                 if queues:  # standard gate

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -309,6 +309,7 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
         self, circuit, initial_state=None, nshots=None, return_array=False
     ):
         import joblib
+        from qibo.gates import M
         from qibo.states import CircuitResult
 
         if not circuit.queues.queues:


### PR DESCRIPTION
This PR fixes an issue raised by @scarrazza when running circuits with accelerators and measurement registers using cupy https://github.com/qiboteam/qibo/pull/769#issuecomment-1399516953. The issue can be reproduced by
```python
from qibo import gates, models
from qibo.backends import construct_backend

backend=construct_backend("qibojit", "cupy")
accelerators = {"/GPU:0": 1, "/GPU:1": 1}
c = models.Circuit(6, accelerators)
c.add([gates.X(0), gates.X(1), gates.X(3)])
ma = c.add(gates.M(5, 1, 3, register_name="a"))
mb = c.add(gates.M(2, 0, register_name="b"))
result = backend.execute_circuit(c, nshots=100)

ma_freq = ma.frequencies()
mb_freq = mb.frequencies()
frequencies = result.frequencies(registers=True)
```