### PR TITLE
limit publish criteria

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,5 +17,5 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-      publish: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+      publish: ${{ github.event_name == 'release' && github.event.action == 'published' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' }}
     secrets: inherit


### PR DESCRIPTION
Upload artifacts only for ubuntu with python 3.9. 
This is required otherwise pypi complains about duplicates, see [here](https://github.com/qiboteam/qibojit/actions/runs/4092900304/jobs/7057954527#step:7:41).