### PR TITLE
Identity density matrix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
     uses: qiboteam/workflows/.github/workflows/deploy-pip.yml@main
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
     uses: qiboteam/workflows/.github/workflows/rules.yml@main
     with:
       os: ${{ matrix.os }}

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     extras_require={
         "tests": ["pytest"],
     },
-    python_requires=">=3.7.0",
+    python_requires=">=3.8.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
 )

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    install_requires=["numba>=0.51.0", "scipy", "psutil", "qibo>0.1.11"],
+    install_requires=["numba>=0.51.0", "scipy", "psutil", "qibo>=0.1.11"],
     extras_require={
         "tests": ["pytest"],
     },

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    install_requires=["numba>=0.51.0", "scipy", "psutil", "qibo>0.1.8"],
+    install_requires=["numba>=0.51.0", "scipy", "psutil", "qibo>0.1.11"],
     extras_require={
         "tests": ["pytest"],
     },

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -159,7 +159,7 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
     def identity_density_matrix(self, nqubits):
         n = 1 << nqubits
         kernel = self.gates.get(f"initial_state_kernel_{self.kernel_type}")
-        state = self.cp.eye(n, n, dtype=self.dtype)
+        state = self.cp.eye(n, dtype=self.dtype)
         kernel((1,), (1,), [state])
         self.cp.cuda.stream.get_current_stream().synchronize()
         state /= 2**nqubits

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -156,6 +156,15 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
         self.cp.cuda.stream.get_current_stream().synchronize()
         return state.reshape((n, n))
 
+    def identity_density_matrix(self, nqubits):
+        n = 1 << nqubits
+        kernel = self.gates.get(f"initial_state_kernel_{self.kernel_type}")
+        state = self.cp.eye(n, n, dtype=self.dtype)
+        kernel((1,), (1,), [state])
+        self.cp.cuda.stream.get_current_stream().synchronize()
+        state /= 2**nqubits
+        return state.reshape((n, n))
+
     def plus_state(self, nqubits):
         state = self.cp.ones(2**nqubits, dtype=self.dtype)
         state /= self.cp.sqrt(2**nqubits)

--- a/src/qibojit/backends/matrices.py
+++ b/src/qibojit/backends/matrices.py
@@ -3,18 +3,7 @@ import sys
 import numpy as np
 from qibo.backends.npmatrices import NumpyMatrices
 
-if sys.version_info.minor >= 8:
-    from functools import cached_property  # pylint: disable=E0611
-else:
-    # Custom ``cached_property`` because it is not available for Python < 3.8
-    from functools import lru_cache
-
-    def cached_property(func):  # pragma: no cover
-        @property
-        def wrapper(self):
-            return lru_cache()(func)(self)
-
-        return wrapper
+from functools import cached_property  # pylint: disable=E0611
 
 
 class CuQuantumMatrices(NumpyMatrices):

--- a/src/qibojit/backends/matrices.py
+++ b/src/qibojit/backends/matrices.py
@@ -1,9 +1,8 @@
 import sys
+from functools import cached_property  # pylint: disable=E0611
 
 import numpy as np
 from qibo.backends.npmatrices import NumpyMatrices
-
-from functools import cached_property  # pylint: disable=E0611
 
 
 class CuQuantumMatrices(NumpyMatrices):

--- a/src/qibojit/tests/test_ops.py
+++ b/src/qibojit/tests/test_ops.py
@@ -24,6 +24,13 @@ def test_zero_state(backend, dtype, is_matrix):
     backend.assert_allclose(final_state, target_state)
 
 
+def test_identity_density_matrix(backend, dtype):
+    set_precision(dtype, backend)
+    final_state = backend.identity_density_matrix(4)
+    target_state = np.eye(16, 16, dtype=dtype) / 16
+    backend.assert_allclose(final_state, target_state)
+
+
 @pytest.mark.parametrize("is_matrix", [False, True])
 def test_plus_state(backend, dtype, is_matrix):
     set_precision(dtype, backend)


### PR DESCRIPTION
This PR implements the identity as a density matrix. It is necessary to use the `DepolarizingChannel` with density matrices on `cupy`, which is implemented in PR [819](https://github.com/qiboteam/qibo/pull/819).