### PR TITLE
Fixes bug in `backend.apply_channel_density_matrix` for quantum-to-classical channels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
     uses: qiboteam/workflows/.github/workflows/deploy-pip.yml@main
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
     uses: qiboteam/workflows/.github/workflows/rules.yml@main
     with:
       os: ${{ matrix.os }}

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     extras_require={
         "tests": ["pytest"],
     },
-    python_requires=">=3.7.0",
+    python_requires=">=3.8.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
 )

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    install_requires=["numba>=0.51.0", "scipy", "psutil", "qibo>=0.1.12.dev0"],
+    install_requires=["numba>=0.51.0", "scipy", "psutil", "qibo>=0.1.11"],
     extras_require={
         "tests": ["pytest"],
     },

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    install_requires=["numba>=0.51.0", "scipy", "psutil", "qibo>0.1.8"],
+    install_requires=["numba>=0.51.0", "scipy", "psutil", "qibo>0.1.11"],
     extras_require={
         "tests": ["pytest"],
     },

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    install_requires=["numba>=0.51.0", "scipy", "psutil", "qibo>0.1.11"],
+    install_requires=["numba>=0.51.0", "scipy", "psutil", "qibo>=0.1.12.dev0"],
     extras_require={
         "tests": ["pytest"],
     },

--- a/src/qibojit/backends/cpu.py
+++ b/src/qibojit/backends/cpu.py
@@ -236,12 +236,17 @@ class NumbaBackend(NumpyBackend):
 
     def apply_channel_density_matrix(self, channel, state, nqubits):
         state = self.cast(state)
+        if channel.name == "ReadoutErrorChannel":
+            state_copy = self.cast(state, copy=True)
         new_state = (1 - channel.coefficient_sum) * state
         for coeff, gate in zip(channel.coefficients, channel.gates):
             state = self.apply_gate_density_matrix(gate, state, nqubits)
             new_state += coeff * state
             # reset the state
-            state = self.apply_gate_density_matrix(gate, state, nqubits, inverse=True)
+            if channel.name == "ReadoutErrorChannel":
+                state = state_copy
+            else:
+                state = self.apply_gate_density_matrix(gate, state, nqubits, inverse=True)
         return new_state
 
     def collapse_state(self, state, qubits, shot, nqubits, normalize=True):

--- a/src/qibojit/backends/cpu.py
+++ b/src/qibojit/backends/cpu.py
@@ -246,7 +246,9 @@ class NumbaBackend(NumpyBackend):
             if channel.name == "ReadoutErrorChannel":
                 state = state_copy
             else:
-                state = self.apply_gate_density_matrix(gate, state, nqubits, inverse=True)
+                state = self.apply_gate_density_matrix(
+                    gate, state, nqubits, inverse=True
+                )
         return new_state
 
     def collapse_state(self, state, qubits, shot, nqubits, normalize=True):

--- a/src/qibojit/backends/cpu.py
+++ b/src/qibojit/backends/cpu.py
@@ -2,6 +2,7 @@ import numpy as np
 from qibo.backends.numpy import NumpyBackend
 from qibo.config import log
 from qibo.gates.abstract import ParametrizedGate
+from qibo.gates.channels import ReadoutErrorChannel
 from qibo.gates.special import FusedGate
 
 from qibojit.backends.matrices import CustomMatrices
@@ -236,15 +237,15 @@ class NumbaBackend(NumpyBackend):
 
     def apply_channel_density_matrix(self, channel, state, nqubits):
         state = self.cast(state)
-        if channel.name == "ReadoutErrorChannel":
+        if isinstance(channel, ReadoutErrorChannel) is True:
             state_copy = self.cast(state, copy=True)
         new_state = (1 - channel.coefficient_sum) * state
         for coeff, gate in zip(channel.coefficients, channel.gates):
             state = self.apply_gate_density_matrix(gate, state, nqubits)
             new_state += coeff * state
             # reset the state
-            if channel.name == "ReadoutErrorChannel":
-                state = state_copy
+            if isinstance(channel, ReadoutErrorChannel) is True:
+                state = self.cast(state_copy, copy=True)
             else:
                 state = self.apply_gate_density_matrix(
                     gate, state, nqubits, inverse=True

--- a/src/qibojit/tests/test_gates.py
+++ b/src/qibojit/tests/test_gates.py
@@ -31,10 +31,8 @@ ATOL = {"complex64": 1e-4, "complex128": 1e-10}
     ],
 )
 def test_apply_gate(backend, nqubits, target, controls, dtype):
-    state = random_statevector(2**nqubits)
-    state = backend.cast(state, dtype=dtype)
-    matrix = random_unitary(2**1)
-    matrix = backend.cast(matrix, dtype=dtype)
+    state = random_statevector(2**nqubits).astype(dtype)
+    matrix = random_unitary(2**1).astype(dtype)
     gate = gates.Unitary(matrix, target).controlled_by(*controls)
 
     tbackend = NumpyBackend()
@@ -47,8 +45,7 @@ def test_apply_gate(backend, nqubits, target, controls, dtype):
 @pytest.mark.parametrize(("nqubits", "target"), [(4, 1), (6, 5)])
 @pytest.mark.parametrize("use_qubits", [False, True])
 def test_one_qubit_base(backend, nqubits, target, use_qubits, dtype):
-    state = random_statevector(2**nqubits)
-    state = backend.cast(state, dtype=dtype)
+    state = random_statevector(2**nqubits).astype(dtype)
     matrix = random_complex((2, 2), dtype=dtype)
     gate = gates.Unitary(matrix, target)
 
@@ -76,8 +73,7 @@ def test_one_qubit_base(backend, nqubits, target, use_qubits, dtype):
 )
 @pytest.mark.parametrize("pauli", ["X", "Y", "Z"])
 def test_apply_pauli_gate(backend, nqubits, target, pauli, controls, dtype):
-    state = random_statevector(2**nqubits)
-    state = backend.cast(state, dtype=dtype)
+    state = random_statevector(2**nqubits).astype(dtype)
     gate = getattr(gates, pauli)
     gate = gate(target).controlled_by(*controls)
 
@@ -93,8 +89,7 @@ def test_apply_pauli_gate(backend, nqubits, target, pauli, controls, dtype):
     [(3, 0, []), (3, 2, [1]), (3, 2, [0, 1]), (6, 1, [0, 2, 4])],
 )
 def test_apply_zpow_gate(backend, nqubits, target, controls, dtype):
-    state = random_statevector(2**nqubits)
-    state = backend.cast(state, dtype=dtype)
+    state = random_statevector(2**nqubits).astype(dtype)
     theta = 0.1234
     gate = gates.U1(target, theta=theta).controlled_by(*controls)
 
@@ -124,12 +119,10 @@ def test_apply_two_qubit_gate(
     backend, nqubits, targets, controls, density_matrix, dtype
 ):
     if density_matrix:
-        state = random_density_matrix(2**nqubits)
-        state = backend.cast(state, dtype=dtype)
+        state = random_density_matrix(2**nqubits).astype(dtype)
     else:
-        state = random_statevector(2**nqubits)
-    matrix = random_unitary(2**2)
-    matrix = backend.cast(matrix, dtype=dtype)
+        state = random_statevector(2**nqubits).astype(dtype)
+    matrix = random_unitary(2**2).astype(dtype)
     gate = gates.Unitary(matrix, *targets).controlled_by(*controls)
 
     tbackend = NumpyBackend()
@@ -146,8 +139,7 @@ def test_apply_two_qubit_gate(
 @pytest.mark.parametrize(("nqubits", "targets"), [(5, [3, 4]), (4, [2, 0])])
 @pytest.mark.parametrize("use_qubits", [False, True])
 def test_apply_two_qubit_base(backend, nqubits, targets, use_qubits, dtype):
-    state = random_statevector(2**nqubits)
-    state = backend.cast(state, dtype=dtype)
+    state = random_statevector(2**nqubits).astype(dtype)
     matrix = random_complex((4, 4), dtype=dtype)
     gate = gates.Unitary(matrix, *targets)
 
@@ -177,8 +169,7 @@ def test_apply_two_qubit_base(backend, nqubits, targets, use_qubits, dtype):
     ],
 )
 def test_apply_swap(backend, nqubits, targets, controls, dtype):
-    state = random_statevector(2**nqubits)
-    state = backend.cast(state, dtype=dtype)
+    state = random_statevector(2**nqubits).astype(dtype)
     gate = gates.SWAP(*targets).controlled_by(*controls)
 
     tbackend = NumpyBackend()
@@ -205,8 +196,7 @@ def test_apply_swap(backend, nqubits, targets, controls, dtype):
     ],
 )
 def test_apply_fsim(backend, nqubits, targets, controls, dtype):
-    state = random_statevector(2**nqubits)
-    state = backend.cast(state, dtype=dtype)
+    state = random_statevector(2**nqubits).astype(dtype)
     matrix = random_complex((2, 2), dtype=dtype)
     phi = 0.4321
     gate = gates.GeneralizedfSim(*targets, matrix, phi).controlled_by(*controls)
@@ -241,10 +231,9 @@ def test_apply_multiqubit_gate(
     backend, nqubits, targets, controls, density_matrix, dtype
 ):
     if density_matrix:
-        state = random_density_matrix(2**nqubits)
+        state = random_density_matrix(2**nqubits).astype(dtype)
     else:
-        state = random_statevector(2**nqubits)
-    state = backend.cast(state, dtype=dtype)
+        state = random_statevector(2**nqubits).astype(dtype)
     rank = 2 ** len(targets)
     matrix = random_complex((rank, rank), dtype=dtype)
     gate = gates.Unitary(matrix, *targets).controlled_by(*controls)
@@ -283,8 +272,7 @@ def test_apply_multiqubit_gate_large(backend, nqubits, targets, controls, dtype)
 @pytest.mark.parametrize(("nqubits", "targets"), [(5, [2, 3, 4]), (4, [2, 0, 1])])
 @pytest.mark.parametrize("use_qubits", [False, True])
 def test_apply_multi_qubit_base(backend, nqubits, targets, use_qubits, dtype):
-    state = random_statevector(2**nqubits)
-    state = backend.cast(state, dtype=dtype)
+    state = random_statevector(2**nqubits).astype(dtype)
     matrix = random_complex((8, 8), dtype=dtype)
     gate = gates.Unitary(matrix, *targets)
 
@@ -362,15 +350,14 @@ def test_density_matrix_half_calls(backend, gatename):
 
 
 def test_unitary_channel(backend, dtype):
-    a1 = np.array([[0, 1], [1, 0]])
-    a2 = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
+    tbackend = NumpyBackend()
+    a1 = gates.X(0).asmatrix(tbackend)
+    a2 = gates.CNOT(0, 1).asmatrix(tbackend)
     probs = [0.4, 0.3]
     matrices = [((0,), a1), ((2, 3), a2)]
     channel = gates.UnitaryChannel(probs, matrices)
-    state = random_density_matrix(2**4)
-    state = backend.cast(state, dtype=dtype)
+    state = random_density_matrix(2**4).astype(dtype)
 
-    tbackend = NumpyBackend()
     set_precision(dtype, backend, tbackend)
     target_state = tbackend.apply_channel_density_matrix(channel, np.copy(state), 4)
     final_state = backend.apply_channel_density_matrix(channel, np.copy(state), 4)

--- a/src/qibojit/tests/test_gates.py
+++ b/src/qibojit/tests/test_gates.py
@@ -32,7 +32,9 @@ ATOL = {"complex64": 1e-4, "complex128": 1e-10}
 )
 def test_apply_gate(backend, nqubits, target, controls, dtype):
     state = random_statevector(2**nqubits)
+    state = backend.cast(state, dtype=dtype)
     matrix = random_unitary(2**1)
+    matrix = backend.cast(matrix, dtype=dtype)
     gate = gates.Unitary(matrix, target).controlled_by(*controls)
 
     tbackend = NumpyBackend()
@@ -46,7 +48,8 @@ def test_apply_gate(backend, nqubits, target, controls, dtype):
 @pytest.mark.parametrize("use_qubits", [False, True])
 def test_one_qubit_base(backend, nqubits, target, use_qubits, dtype):
     state = random_statevector(2**nqubits)
-    matrix = random_complex((2, 2))
+    state = backend.cast(state, dtype=dtype)
+    matrix = random_complex((2, 2), dtype=dtype)
     gate = gates.Unitary(matrix, target)
 
     tbackend = NumpyBackend()
@@ -74,6 +77,7 @@ def test_one_qubit_base(backend, nqubits, target, use_qubits, dtype):
 @pytest.mark.parametrize("pauli", ["X", "Y", "Z"])
 def test_apply_pauli_gate(backend, nqubits, target, pauli, controls, dtype):
     state = random_statevector(2**nqubits)
+    state = backend.cast(state, dtype=dtype)
     gate = getattr(gates, pauli)
     gate = gate(target).controlled_by(*controls)
 
@@ -90,6 +94,7 @@ def test_apply_pauli_gate(backend, nqubits, target, pauli, controls, dtype):
 )
 def test_apply_zpow_gate(backend, nqubits, target, controls, dtype):
     state = random_statevector(2**nqubits)
+    state = backend.cast(state, dtype=dtype)
     theta = 0.1234
     gate = gates.U1(target, theta=theta).controlled_by(*controls)
 
@@ -120,9 +125,11 @@ def test_apply_two_qubit_gate(
 ):
     if density_matrix:
         state = random_density_matrix(2**nqubits)
+        state = backend.cast(state, dtype=dtype)
     else:
         state = random_statevector(2**nqubits)
     matrix = random_unitary(2**2)
+    matrix = backend.cast(matrix, dtype=dtype)
     gate = gates.Unitary(matrix, *targets).controlled_by(*controls)
 
     tbackend = NumpyBackend()
@@ -140,7 +147,8 @@ def test_apply_two_qubit_gate(
 @pytest.mark.parametrize("use_qubits", [False, True])
 def test_apply_two_qubit_base(backend, nqubits, targets, use_qubits, dtype):
     state = random_statevector(2**nqubits)
-    matrix = random_complex((4, 4))
+    state = backend.cast(state, dtype=dtype)
+    matrix = random_complex((4, 4), dtype=dtype)
     gate = gates.Unitary(matrix, *targets)
 
     tbackend = NumpyBackend()
@@ -170,6 +178,7 @@ def test_apply_two_qubit_base(backend, nqubits, targets, use_qubits, dtype):
 )
 def test_apply_swap(backend, nqubits, targets, controls, dtype):
     state = random_statevector(2**nqubits)
+    state = backend.cast(state, dtype=dtype)
     gate = gates.SWAP(*targets).controlled_by(*controls)
 
     tbackend = NumpyBackend()
@@ -197,7 +206,8 @@ def test_apply_swap(backend, nqubits, targets, controls, dtype):
 )
 def test_apply_fsim(backend, nqubits, targets, controls, dtype):
     state = random_statevector(2**nqubits)
-    matrix = random_complex((2, 2))
+    state = backend.cast(state, dtype=dtype)
+    matrix = random_complex((2, 2), dtype=dtype)
     phi = 0.4321
     gate = gates.GeneralizedfSim(*targets, matrix, phi).controlled_by(*controls)
 
@@ -234,8 +244,9 @@ def test_apply_multiqubit_gate(
         state = random_density_matrix(2**nqubits)
     else:
         state = random_statevector(2**nqubits)
+    state = backend.cast(state, dtype=dtype)
     rank = 2 ** len(targets)
-    matrix = random_complex((rank, rank))
+    matrix = random_complex((rank, rank), dtype=dtype)
     gate = gates.Unitary(matrix, *targets).controlled_by(*controls)
 
     tbackend = NumpyBackend()
@@ -273,7 +284,8 @@ def test_apply_multiqubit_gate_large(backend, nqubits, targets, controls, dtype)
 @pytest.mark.parametrize("use_qubits", [False, True])
 def test_apply_multi_qubit_base(backend, nqubits, targets, use_qubits, dtype):
     state = random_statevector(2**nqubits)
-    matrix = random_complex((8, 8))
+    state = backend.cast(state, dtype=dtype)
+    matrix = random_complex((8, 8), dtype=dtype)
     gate = gates.Unitary(matrix, *targets)
 
     tbackend = NumpyBackend()
@@ -356,6 +368,7 @@ def test_unitary_channel(backend, dtype):
     matrices = [((0,), a1), ((2, 3), a2)]
     channel = gates.UnitaryChannel(probs, matrices)
     state = random_density_matrix(2**4)
+    state = backend.cast(state, dtype=dtype)
 
     tbackend = NumpyBackend()
     set_precision(dtype, backend, tbackend)

--- a/src/qibojit/tests/test_gates.py
+++ b/src/qibojit/tests/test_gates.py
@@ -2,15 +2,15 @@ import numpy as np
 import pytest
 from qibo import gates
 from qibo.backends import NumpyBackend
-
-from qibojit.tests.utils import (
-    qubits_tensor,
-    random_complex,
+from qibo.config import PRECISION_TOL
+from qibo.quantum_info import (
     random_density_matrix,
-    random_state,
+    random_statevector,
+    random_stochastic_matrix,
     random_unitary,
-    set_precision,
 )
+
+from qibojit.tests.utils import qubits_tensor, random_complex, set_precision
 
 ATOL = {"complex64": 1e-4, "complex128": 1e-10}
 
@@ -31,8 +31,8 @@ ATOL = {"complex64": 1e-4, "complex128": 1e-10}
     ],
 )
 def test_apply_gate(backend, nqubits, target, controls, dtype):
-    state = random_state(nqubits, dtype=dtype)
-    matrix = random_unitary(1, dtype=dtype)
+    state = random_statevector(2**nqubits)
+    matrix = random_unitary(2**1)
     gate = gates.Unitary(matrix, target).controlled_by(*controls)
 
     tbackend = NumpyBackend()
@@ -45,8 +45,8 @@ def test_apply_gate(backend, nqubits, target, controls, dtype):
 @pytest.mark.parametrize(("nqubits", "target"), [(4, 1), (6, 5)])
 @pytest.mark.parametrize("use_qubits", [False, True])
 def test_one_qubit_base(backend, nqubits, target, use_qubits, dtype):
-    state = random_state(nqubits, dtype=dtype)
-    matrix = random_complex((2, 2), dtype=dtype)
+    state = random_statevector(2**nqubits)
+    matrix = random_complex((2, 2))
     gate = gates.Unitary(matrix, target)
 
     tbackend = NumpyBackend()
@@ -73,7 +73,7 @@ def test_one_qubit_base(backend, nqubits, target, use_qubits, dtype):
 )
 @pytest.mark.parametrize("pauli", ["X", "Y", "Z"])
 def test_apply_pauli_gate(backend, nqubits, target, pauli, controls, dtype):
-    state = random_state(nqubits, dtype=dtype)
+    state = random_statevector(2**nqubits)
     gate = getattr(gates, pauli)
     gate = gate(target).controlled_by(*controls)
 
@@ -89,7 +89,7 @@ def test_apply_pauli_gate(backend, nqubits, target, pauli, controls, dtype):
     [(3, 0, []), (3, 2, [1]), (3, 2, [0, 1]), (6, 1, [0, 2, 4])],
 )
 def test_apply_zpow_gate(backend, nqubits, target, controls, dtype):
-    state = random_state(nqubits, dtype=dtype)
+    state = random_statevector(2**nqubits)
     theta = 0.1234
     gate = gates.U1(target, theta=theta).controlled_by(*controls)
 
@@ -119,10 +119,10 @@ def test_apply_two_qubit_gate(
     backend, nqubits, targets, controls, density_matrix, dtype
 ):
     if density_matrix:
-        state = random_density_matrix(nqubits, dtype=dtype)
+        state = random_density_matrix(2**nqubits)
     else:
-        state = random_state(nqubits, dtype=dtype)
-    matrix = random_unitary(2, dtype=dtype)
+        state = random_statevector(2**nqubits)
+    matrix = random_unitary(2**2)
     gate = gates.Unitary(matrix, *targets).controlled_by(*controls)
 
     tbackend = NumpyBackend()
@@ -139,8 +139,8 @@ def test_apply_two_qubit_gate(
 @pytest.mark.parametrize(("nqubits", "targets"), [(5, [3, 4]), (4, [2, 0])])
 @pytest.mark.parametrize("use_qubits", [False, True])
 def test_apply_two_qubit_base(backend, nqubits, targets, use_qubits, dtype):
-    state = random_state(nqubits, dtype=dtype)
-    matrix = random_complex((4, 4), dtype=dtype)
+    state = random_statevector(2**nqubits)
+    matrix = random_complex((4, 4))
     gate = gates.Unitary(matrix, *targets)
 
     tbackend = NumpyBackend()
@@ -169,7 +169,7 @@ def test_apply_two_qubit_base(backend, nqubits, targets, use_qubits, dtype):
     ],
 )
 def test_apply_swap(backend, nqubits, targets, controls, dtype):
-    state = random_state(nqubits, dtype=dtype)
+    state = random_statevector(2**nqubits)
     gate = gates.SWAP(*targets).controlled_by(*controls)
 
     tbackend = NumpyBackend()
@@ -196,8 +196,8 @@ def test_apply_swap(backend, nqubits, targets, controls, dtype):
     ],
 )
 def test_apply_fsim(backend, nqubits, targets, controls, dtype):
-    state = random_state(nqubits, dtype=dtype)
-    matrix = random_complex((2, 2), dtype=dtype)
+    state = random_statevector(2**nqubits)
+    matrix = random_complex((2, 2))
     phi = 0.4321
     gate = gates.GeneralizedfSim(*targets, matrix, phi).controlled_by(*controls)
 
@@ -231,11 +231,11 @@ def test_apply_multiqubit_gate(
     backend, nqubits, targets, controls, density_matrix, dtype
 ):
     if density_matrix:
-        state = random_density_matrix(nqubits, dtype=dtype)
+        state = random_density_matrix(2**nqubits)
     else:
-        state = random_state(nqubits, dtype=dtype)
+        state = random_statevector(2**nqubits)
     rank = 2 ** len(targets)
-    matrix = random_complex((rank, rank), dtype=dtype)
+    matrix = random_complex((rank, rank))
     gate = gates.Unitary(matrix, *targets).controlled_by(*controls)
 
     tbackend = NumpyBackend()
@@ -272,8 +272,8 @@ def test_apply_multiqubit_gate_large(backend, nqubits, targets, controls, dtype)
 @pytest.mark.parametrize(("nqubits", "targets"), [(5, [2, 3, 4]), (4, [2, 0, 1])])
 @pytest.mark.parametrize("use_qubits", [False, True])
 def test_apply_multi_qubit_base(backend, nqubits, targets, use_qubits, dtype):
-    state = random_state(nqubits, dtype=dtype)
-    matrix = random_complex((8, 8), dtype=dtype)
+    state = random_statevector(2**nqubits)
+    matrix = random_complex((8, 8))
     gate = gates.Unitary(matrix, *targets)
 
     tbackend = NumpyBackend()
@@ -295,9 +295,9 @@ def test_gates_on_circuit(backend, gatename, density_matrix):
     from qibo.models import Circuit
 
     if density_matrix:
-        state = random_density_matrix(1)
+        state = random_density_matrix(2**1)
     else:
-        state = random_state(1)
+        state = random_statevector(2**1)
 
     c = Circuit(1, density_matrix=density_matrix)
     c.add(getattr(gates, gatename)(0))
@@ -325,9 +325,9 @@ def test_parametrized_gates_on_circuit(backend, gatename, params, density_matrix
     from qibo.models import Circuit
 
     if density_matrix:
-        state = random_density_matrix(2)
+        state = random_density_matrix(2**2)
     else:
-        state = random_state(2)
+        state = random_statevector(2**2)
 
     c = Circuit(2, density_matrix=density_matrix)
     c.add(getattr(gates, gatename)(0, 1, **params))
@@ -340,7 +340,7 @@ def test_parametrized_gates_on_circuit(backend, gatename, params, density_matrix
 
 @pytest.mark.parametrize("gatename", ["H", "X", "Z"])
 def test_density_matrix_half_calls(backend, gatename):
-    state = random_density_matrix(3)
+    state = random_density_matrix(2**3)
     gate = getattr(gates, gatename)(1)
 
     tbackend = NumpyBackend()
@@ -355,10 +355,25 @@ def test_unitary_channel(backend, dtype):
     probs = [0.4, 0.3]
     matrices = [((0,), a1), ((2, 3), a2)]
     channel = gates.UnitaryChannel(probs, matrices)
-    state = random_density_matrix(4, dtype=dtype)
+    state = random_density_matrix(2**4)
 
     tbackend = NumpyBackend()
     set_precision(dtype, backend, tbackend)
     target_state = tbackend.apply_channel_density_matrix(channel, np.copy(state), 4)
     final_state = backend.apply_channel_density_matrix(channel, np.copy(state), 4)
     backend.assert_allclose(final_state, target_state)
+
+
+def test_readout_error_channel(backend):
+    nqubits = 1
+    d = 2**nqubits
+
+    rho = random_density_matrix(d, seed=1)
+    P = random_stochastic_matrix(d, seed=1)
+
+    probability_sum = gates.ReadoutErrorChannel(0, P).apply_density_matrix(
+        backend, rho, 1
+    )
+    probability_sum = np.diag(probability_sum).sum().real
+
+    backend.assert_allclose(probability_sum - 1 < PRECISION_TOL, True)

--- a/src/qibojit/tests/test_ops.py
+++ b/src/qibojit/tests/test_ops.py
@@ -2,13 +2,9 @@ import itertools
 
 import numpy as np
 import pytest
+from qibo.quantum_info import random_statevector
 
-from qibojit.tests.utils import (
-    qubits_tensor,
-    random_complex,
-    random_state,
-    set_precision,
-)
+from qibojit.tests.utils import qubits_tensor, random_complex, set_precision
 
 
 @pytest.mark.parametrize("is_matrix", [False, True])
@@ -51,7 +47,8 @@ def test_plus_state(backend, dtype, is_matrix):
 @pytest.mark.parametrize("normalize", [True, False])
 def test_collapse_state(backend, nqubits, targets, results, normalize, dtype):
     atol = 1e-7 if dtype == "complex64" else 1e-14
-    state = random_state(nqubits, dtype)
+    state = random_statevector(2**nqubits)
+    state = backend.cast(state, dtype=dtype)
     slicer = nqubits * [slice(None)]
     for t, r in zip(targets, results):
         slicer[t] = r
@@ -80,7 +77,7 @@ def test_collapse_call(backend, density_matrix):
         state = state + np.conj(state.T)
         state = state / np.trace(state)
     else:
-        state = random_state(3)
+        state = random_statevector(2**3)
 
     tbackend = NumpyBackend()
     gate = gates.M(0, 1, collapse=True)
@@ -114,7 +111,8 @@ def test_transpose_state(backend, nqubits, qubits, ndevices, dtype):
             f"``transpose_state`` op is not available for {backend.platform} platform."
         )
     qubit_order = list(qubits)
-    state = random_state(nqubits, dtype)
+    state = random_statevector(2**nqubits)
+    state = backend.cast(state, dtype=dtype)
     state_tensor = np.reshape(state, nqubits * (2,))
     target_state = np.transpose(state_tensor, qubit_order).flatten()
     new_state = np.zeros_like(state)
@@ -136,7 +134,8 @@ def test_swap_pieces_zero_global(backend, nqubits, local, dtype):
 
     from qibo import gates
 
-    state = random_state(nqubits, dtype)
+    state = random_statevector(2**nqubits)
+    state = backend.cast(state, dtype=dtype)
     target_state = np.copy(state)
     shape = (2, int(state.shape[0]) // 2)
     state = np.reshape(state, shape)
@@ -167,7 +166,8 @@ def test_swap_pieces(backend, nqubits, qlocal, qglobal, dtype):
 
     from qibo import gates
 
-    state = random_state(nqubits, dtype)
+    state = random_statevector(2**nqubits)
+    state = backend.cast(state, dtype=dtype)
     target_state = np.copy(state)
     shape = (2, int(state.shape[0]) // 2)
 

--- a/src/qibojit/tests/utils.py
+++ b/src/qibojit/tests/utils.py
@@ -12,24 +12,6 @@ def random_complex(shape, dtype="complex128"):
     return x.astype(dtype)
 
 
-def random_state(nqubits, dtype="complex128"):
-    x = random_complex((2**nqubits,), dtype=dtype)
-    return x / np.sqrt(np.sum(np.abs(x) ** 2))
-
-
-def random_density_matrix(nqubits, dtype="complex128"):
-    x = random_complex(2 * (2**nqubits,), dtype=dtype)
-    return x / np.trace(x)
-
-
-def random_unitary(nqubits, dtype="complex128"):
-    from scipy.linalg import expm
-
-    shape = 2 * (2**nqubits,)
-    m = random_complex(shape, dtype=dtype)
-    return expm(1j * (m + m.T.conj()))
-
-
 def set_precision(dtype, *backends):
     if dtype == "complex64":
         precision = "single"


### PR DESCRIPTION
This closed #108 and fixes test issues in https://github.com/qiboteam/qibo/pull/810

PS: I don't have permissions in this repo, this is why I'm pushing this fix from my fork.