### PR TITLE
adding build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "qibojit"
 version = "0.1.0"


### PR DESCRIPTION
Includes the `build-system` section so pip knows the version when installing from source.