### PR TITLE
Fix cupy for real number precisions

### DIFF
--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -615,19 +615,25 @@ class CuQuantumBackend(CupyBackend):  # pragma: no cover
             self.cusv.destroy(self.handle)
 
     def set_dtype(self, dtype):
+        if dtype in ("float32", "float64"):
+            raise_error(
+                NotImplementedError,
+                "``CuQuantumBackend only supports data types ``complex64`` and ``complex128``.",
+            )
+
         if dtype != self.dtype:
             super().set_dtype(dtype)
             if self.custom_matrices:
                 self.custom_matrices = CustomCuQuantumMatrices(self.dtype)
 
     def get_cuda_type(self, dtype="complex64"):
-        if dtype not in ("complex128", "complex64", "float64", "float32"):
+        if dtype not in ("complex128", "complex64"):
             raise_error(
-                TypeError,
-                "Type must be one of (``complex64``, ``complex128``, ``float64``, ``float32``).",
+                NotImplementedError,
+                "``CuQuantumBackend only supports data types ``complex64`` and ``complex128``.",
             )
 
-        if dtype in ("complex128", "float64"):
+        if dtype == "complex128":
             return (
                 self.cuquantum.cudaDataType.CUDA_C_64F,
                 self.cuquantum.ComputeType.COMPUTE_64F,

--- a/src/qibojit/backends/gpu.py
+++ b/src/qibojit/backends/gpu.py
@@ -47,7 +47,6 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
         self.npsparse = sparse
         self.sparse = cp_sparse
         self.device = "/GPU:0"
-        self.kernel_type = "double"
         self.matrices = CupyMatrices(self.dtype)
         self.custom_matrices = CustomMatrices(self.dtype)
         self.custom_matrices._cast = self.matrices._cast
@@ -75,29 +74,43 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
         self.gates = {}
         from qibojit.custom_operators import raw_kernels
 
-        def kernel_loader(name, ktype):
-            code = getattr(raw_kernels, name)
-            code = code.replace("T", f"thrust::complex<{ktype}>")
-            gate = cp.RawKernel(code, name, ("--std=c++11",))
-            self.gates[f"{name}_{ktype}"] = gate
+        type_replacements = {
+            "float32": "float",
+            "float64": "double",
+            "complex64": "thrust::complex<float>",
+            "complex128": "thrust::complex<double>",
+        }
 
-        for ktype in ("float", "double"):
+        def kernel_loader(name, dtype):
+            code = getattr(raw_kernels, name)
+            code = code.replace("T", type_replacements[dtype])
+            if name == "initial_state_kernel":
+                body = (
+                    "state[0] = 1;"
+                    if dtype in ("float32", "float64")
+                    else f"state[0] = {type_replacements[dtype]}(1, 0);"
+                )
+                code = code.replace("<BODY>", body)
+            gate = cp.RawKernel(code, name, ("--std=c++11",))
+            self.gates[f"{name}_{dtype}"] = gate
+
+        for dtype in type_replacements.keys():
             for name in self.KERNELS:
-                kernel_loader(f"{name}_kernel", ktype)
-                kernel_loader(f"multicontrol_{name}_kernel", ktype)
-            kernel_loader("collapse_state_kernel", ktype)
-            kernel_loader("initial_state_kernel", ktype)
+                kernel_loader(f"{name}_kernel", dtype)
+                kernel_loader(f"multicontrol_{name}_kernel", dtype)
+            kernel_loader("collapse_state_kernel", dtype)
+            kernel_loader("initial_state_kernel", dtype)
 
         # load multiqubit kernels
         name = "apply_multi_qubit_gate_kernel"
         for ntargets in range(3, self.MAX_NUM_TARGETS + 1):
-            for ktype in ("float", "double"):
+            for dtype, ctype in type_replacements.items():
                 code = getattr(raw_kernels, name)
-                code = code.replace("T", f"thrust::complex<{ktype}>")
+                code = code.replace("T", ctype)
                 code = code.replace("nsubstates", str(2**ntargets))
                 code = code.replace("MAX_BLOCK_SIZE", str(self.DEFAULT_BLOCK_SIZE))
                 gate = cp.RawKernel(code, name, ("--std=c++11",))
-                self.gates[f"{name}_{ktype}_{ntargets}"] = gate
+                self.gates[f"{name}_{dtype}_{ntargets}"] = gate
 
         # load numba op for measuring frequencies
         from qibojit.custom_operators.ops import measure_frequencies
@@ -106,13 +119,6 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
 
         # number of available GPUs (for multigpu)
         self.ngpus = cp.cuda.runtime.getDeviceCount()
-
-    def set_dtype(self, dtype):
-        super().set_dtype(dtype)
-        if self.dtype == "complex128":
-            self.kernel_type = "double"
-        elif self.dtype == "complex64":
-            self.kernel_type = "float"
 
     def set_device(self, device):
         if "GPU" not in device:
@@ -174,7 +180,7 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
 
     def zero_state(self, nqubits):
         n = 1 << nqubits
-        kernel = self.gates.get(f"initial_state_kernel_{self.kernel_type}")
+        kernel = self.gates.get(f"initial_state_kernel_{self.dtype}")
         state = self.cp.zeros(n, dtype=self.dtype)
         kernel((1,), (1,), [state])
         self.cp.cuda.stream.get_current_stream().synchronize()
@@ -182,7 +188,7 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
 
     def zero_density_matrix(self, nqubits):
         n = 1 << nqubits
-        kernel = self.gates.get(f"initial_state_kernel_{self.kernel_type}")
+        kernel = self.gates.get(f"initial_state_kernel_{self.dtype}")
         state = self.cp.zeros(n * n, dtype=self.dtype)
         kernel((1,), (1,), [state])
         self.cp.cuda.stream.get_current_stream().synchronize()
@@ -238,10 +244,10 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
             args = (state, tk, m, gate)
 
         if ncontrols:
-            kernel = self.gates.get(f"multicontrol_{kernel}_kernel_{self.kernel_type}")
+            kernel = self.gates.get(f"multicontrol_{kernel}_kernel_{self.dtype}")
             args += (qubits, ncontrols + 1)
         else:
-            kernel = self.gates.get(f"{kernel}_kernel_{self.kernel_type}")
+            kernel = self.gates.get(f"{kernel}_kernel_{self.dtype}")
 
         nblocks, block_size = self.calculate_blocks(nstates)
         kernel((nblocks,), (block_size,), args)
@@ -269,10 +275,10 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
             assert state.dtype == args[-1].dtype
 
         if ncontrols:
-            kernel = self.gates.get(f"multicontrol_{kernel}_kernel_{self.kernel_type}")
+            kernel = self.gates.get(f"multicontrol_{kernel}_kernel_{self.dtype}")
             args += (qubits, ncontrols + 2)
         else:
-            kernel = self.gates.get(f"{kernel}_kernel_{self.kernel_type}")
+            kernel = self.gates.get(f"{kernel}_kernel_{self.dtype}")
 
         nblocks, block_size = self.calculate_blocks(nstates)
         kernel((nblocks,), (block_size,), args)
@@ -299,7 +305,7 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
         nsubstates = 1 << ntargets
         nblocks, block_size = self.calculate_blocks(nstates)
         kernel = self.gates.get(
-            f"apply_multi_qubit_gate_kernel_{self.kernel_type}_{ntargets}"
+            f"apply_multi_qubit_gate_kernel_{self.dtype}_{ntargets}"
         )
         args = (state, gate, qubits, targets, ntargets, nactive)
         kernel((nblocks,), (block_size,), args)
@@ -341,7 +347,7 @@ class CupyBackend(NumbaBackend):  # pragma: no cover
             [nqubits - q - 1 for q in reversed(qubits)], dtype=self.cp.int32
         )
         args = [state, qubits, int(shot), ntargets]
-        kernel = self.gates.get(f"collapse_state_kernel_{self.kernel_type}")
+        kernel = self.gates.get(f"collapse_state_kernel_{self.dtype}")
         kernel((nblocks,), (block_size,), args)
         self.cp.cuda.stream.get_current_stream().synchronize()
 

--- a/src/qibojit/custom_operators/raw_kernels.py
+++ b/src/qibojit/custom_operators/raw_kernels.py
@@ -498,6 +498,6 @@ initial_state_kernel = """
 // to zero in backends.py:CupyBackend.initial_state, then a
 // single thread execute this kernel and set the first element to 1
 extern "C" __global__ void initial_state_kernel(T* state) {
-  state[0] = T(1, 0);
+  <BODY>
 }
 """  # pragma: no cover


### PR DESCRIPTION
I actually realized that on #221 I was overcomplicating things. It is possible to fix this with a much smaller diff and a minimal change in the kernels (only for the initial state one). I used the same test:
```py
import numpy as np
from qibo import Circuit, gates, set_backend, set_dtype


c = Circuit(2)
c.add(gates.H(0))
c.add(gates.CNOT(0, 1))

set_backend("numpy")
target_state = c().state()


set_backend("qibojit", platform="cupy")

for dtype in ("float32", "float64", "complex64", "complex128"):
    set_dtype(dtype)
    final_state = c().state().get()
    np.testing.assert_allclose(final_state, target_state)
```
and it also works here. @renatomello let me know if this also fixes the issues with the qibo tests.

Qibojit tests on GPU also pass on this branch (when ran locally).